### PR TITLE
Add diff and check options

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+# the default ignores minus E704
+ignore = E121,E123,E126,E226,E24,W503,W504

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: python_poetry_package
+
+on:
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run:  |
+              python -m pip install --upgrade pip
+              python -m pip install poetry
+              poetry install --no-interaction
+      - name: Check formatting with black
+        run:  poetry run black --check .
+      - name: Lint with flake8
+        run:  poetry run flake8 --count snakefmt/
+      - name: Test and generate coverage report with pytest
+        run:  |
+              # have to do this as use of tmpdir in tests changes directory
+              covg_report="$(pwd)/coverage.xml"
+              poetry run pytest --cov=snakefmt --cov-report=xml:$covg_report --cov-branch tests/
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file:             ./coverage.xml
+          flags:            unittests
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Check formatting with black
         run:  poetry run black --check .
       - name: Lint with flake8
-        run:  poetry run flake8 --count snakefmt/
+        run:  poetry run flake8 --count .
       - name: Test and generate coverage report with pytest
         run:  |
               # have to do this as use of tmpdir in tests changes directory

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev:  stable
     hooks:
-      - id: black
+      - id:               black
         language_version: python3.6
+  - repo: https://gitlab.com/pycqa/flake8
+    rev:  '3.7.9'
+    hooks:
+      - id: flake8
+        exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,3 @@ repos:
     rev:  '3.7.9'
     hooks:
       - id: flake8
-        exclude: ^tests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,17 @@
 # Contributing
 
-We welcome contributions to `snakefmt`. We outline a [recommended development setup](#recommended-development-workflow) and
-workflow below. Of course, if you have your own system you would prefer to follow, that
-is fine. Regardless of the development process you use, please ensure the code you have
-changed is formatted with `black` as per the specifications in [`pyproject.toml`][pyproject].
+We welcome contributions to `snakefmt`. We outline a
+[recommended development setup](#recommended-development-workflow) and workflow below.
+Of course, if you have your own system you would prefer to follow, that is fine.
+Regardless of the development process you use, please ensure the code you have changed
+is formatted with `black` as per the specifications in [`pyproject.toml`][pyproject] and
+there are no `flake8` warnings in accordance with [`.flake8`][flake8].
 
 ### Recommended development workflow
 
 Firstly, fork this repository. Then run the following.
 
-```bash
+```shell
 # clone your fork locally
 git clone https://github.com/<username>/snakefmt.git
 cd snakefmt
@@ -19,11 +21,13 @@ poetry install
 poetry shell
 # setup the pre-commit hook that will format the project with black
 pre-commit install
-# run tests BEFORE commiting
+# run tests BEFORE committing
 pytest
 ```
 
 You should be all set to go now!
 
 
-[pyproject]: https://github.com/mbhall88/snakefmt/blob/master/pyproject.toml
+[pyproject]: https://github.com/snakemake/snakefmt/blob/master/pyproject.toml
+[flake8]: https://github.com/snakemake/snakefmt/blob/master/.flake8
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 This repository provides formatting for [Snakemake][snakemake] files. It follows the design and specifications of [Black][black].
 
+> **⚠️WARNING⚠️**: As this project is still in the very early stages of development, and thus not stable, we strongly recommend ensuring your files are under version control before doing any formatting. Alternatively, you can pipe the file in from stdin, which will print it to the screen, or use the `--diff` option. See [Usage](#usage) for more details.
+
 [TOC]:#
 
 # Table of Contents

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Snakefmt
+
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/snakemake/snakefmt/python_poetry_package)](https://github.com/snakemake/snakefmt/actions)
 [![codecov](https://codecov.io/gh/snakemake/snakefmt/branch/master/graph/badge.svg)](https://codecov.io/gh/snakemake/snakefmt)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -5,6 +7,21 @@
 ![Python versions](https://img.shields.io/badge/Python%20versions->=3.6-blue)
 
 This repository provides formatting for [Snakemake][snakemake] files. It follows the design and specifications of [Black][black].
+
+[TOC]:#
+
+# Table of Contents
+- [Install](#install)
+- [Usage](#usage)
+  - [Basic Usage](#basic-usage)
+  - [Full Usage](#full-usage)
+- [Design](#design)
+  - [Syntax](#syntax)
+  - [Formatting](#formatting)
+- [Example File](#example-file)
+- [Contributing](#contributing)
+
+
 
 ## Install
 
@@ -17,7 +34,36 @@ poetry shell
 
 ## Usage
 
+### Basic Usage
+
+Format a single Snakefile.
+
+```shell
+snakefmt Snakefile
 ```
+
+Format all Snakefiles within a directory.
+
+```shell
+snakefmt workflows/
+```
+
+Format all Snakefiles under the current directory.
+
+```shell
+snakefmt .
+```
+
+Format a file but write the output to stdout.
+
+```shell
+snakefmt - < Snakefile
+```
+
+### Full Usage
+
+```
+$ snakefmt --help
 Usage: snakefmt [OPTIONS] [SRC]...
 
   The uncompromising Snakemake code formatter.
@@ -63,6 +109,79 @@ Options:
   -V, --version          Show the version and exit.
   -v, --verbose          Turns on debug-level logging.
 ```
+
+#### Check
+##### `--check`
+
+Using the option will not write any formatted code back to file. It will instead check whether any changes *would* be made. It returns one of three possible exit codes:
+
+**0** - indicates **no changes** would be made
+```
+$ echo 'include: "foo.txt"' | snakefmt --check -                                        
+[INFO] 1 file(s) would be left unchanged 🎉
+$ echo "Exit code: $?"
+Exit code: 0
+```
+
+**1** - indicates **changes** would be made
+```
+$ echo 'include:"foo.txt"' | snakefmt --check - 
+[INFO] 1 file(s) would be changed 😬
+$ echo "Exit code: $?"
+Exit code: 1
+```
+
+**123** - indicates there was an **internal error** such as invalid syntax
+```
+$ echo 'include:' | snakefmt --check -            
+[ERROR] L2: In include definition.
+[INFO] 1 file(s) contains errors 🤕
+$ echo "Exit code: $?"
+Exit code: 123
+```
+
+#### Compact diff
+##### `--compact-diff`
+
+As the name implies, a more compact version of [`--diff`](#diff). Using this option will not write any formatted code back to file. It will instead print a compact diff of how the code looks before and after formatting. The diff is compact as it only prints the lines that will change, with a few lines of surrounding context.
+
+```
+$ echo 'x = 1\ny = 3\n\n\nrule foo:\n\tinput: "foo.txt"' | snakefmt --compact-diff -
+=====> Diff for stdin <=====
+
+--- original
++++ new
+@@ -3,4 +3,5 @@
+ 
+ 
+ rule foo:
+-       input: "foo.txt"
++    input:
++        "foo.txt",
+
+[INFO] All done 🎉
+```
+
+The above example shows that the variable assignments at the beginning of the file are not included in the compact diff (but would be included in a full diff).
+
+#### Diff
+##### `--diff`
+
+Using this option will not write any formatted code back to file. It will instead print a diff of how the code looks before and after formatting.
+
+```
+$ echo 'rule foo:\n\tinput: "foo.txt"' | snakefmt --diff -
+=====> Diff for stdin <=====
+
+  rule foo:
+-       input: "foo.txt"
++     input:
++         "foo.txt",
+
+[INFO] All done 🎉
+```
+
+If multiple files are specified, a diff for each file is written to stdout, separated by `=====> Diff for <filepath> <=====`.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -18,26 +18,46 @@ Usage: snakefmt [OPTIONS] [SRC]...
 
   The uncompromising Snakemake code formatter.
 
+  SRC specifies directories and files to format. Directories will be
+  searched for file names that conform to the include/exclude patterns
+  provided.
+
 Options:
-  -l, --line-length INTEGER  [default: 88]
-  --include TEXT             A regular expression that matches files and
-							 directories that should be included on recursive
-							 searches.  An empty value means all files are
-							 included regardless of the name.  Use forward
-							 slashes for directories on all platforms
-							 (Windows, too).  Exclusions are calculated first,
-							 inclusions later.  [default: (\.smk$|^Snakefile)]
-  --exclude TEXT             A regular expression that matches files and
-							 directories that should be excluded on recursive
-							 searches.  An empty value means no paths are
-							 excluded. Use forward slashes for directories on
-							 all platforms (Windows, too). Exclusions are
-							 calculated first, inclusions later.  [default: (\
-							 .snakemake|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\
-							 .tox|\.venv|\.svn|_build|buck-out|build|dist)]
-  -h, --help                 Show this message and exit.
-  -V, --version              Show the version and exit.
-  -v, --verbose              Turns on debug-level logging.
+  -l, --line-length INT  Lines longer than INT will be wrapped.  [default: 88]
+  --check                Don't write the files back, just return the status.
+                         Return code 0 means nothing would change. Return code
+                         1 means some files would be reformatted. Return code
+                         123 means there was an internal error.
+
+  -d, --diff             Don't write the files back, just output a diff for
+                         each file to stdout.
+
+  --compact-diff         Same as --diff but only shows lines that would change
+                         plus a few lines of context.
+
+  --include PATTERN      A regular expression that matches files and
+                         directories that should be included on recursive
+                         searches.  An empty value means all files are
+                         included regardless of the name.  Use forward slashes
+                         for directories on all platforms (Windows, too).
+                         Exclusions are calculated first, inclusions later.
+                         [default: (\.smk$|^Snakefile)]
+
+  --exclude PATTERN      A regular expression that matches files and
+                         directories that should be excluded on recursive
+                         searches.  An empty value means no paths are
+                         excluded. Use forward slashes for directories on all
+                         platforms (Windows, too). Exclusions are calculated
+                         first, inclusions later.  [default: (\.snakemake|\.eg
+                         gs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_
+                         build|buck-out|build|dist)]
+
+  -c, --config PATH      Read configuration from PATH. By default, will try to
+                         read from `./pyproject.toml`
+
+  -h, --help             Show this message and exit.
+  -V, --version          Show the version and exit.
+  -v, --verbose          Turns on debug-level logging.
 ```
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ Format all Snakefiles within a directory.
 snakefmt workflows/
 ```
 
-Format all Snakefiles under the current directory.
-
-```shell
-snakefmt .
-```
-
 Format a file but write the output to stdout.
 
 ```shell
@@ -77,7 +71,7 @@ Options:
   --check                Don't write the files back, just return the status.
                          Return code 0 means nothing would change. Return code
                          1 means some files would be reformatted. Return code
-                         123 means there was an internal error.
+                         123 means there was an error.
 
   -d, --diff             Don't write the files back, just output a diff for
                          each file to stdout.
@@ -108,12 +102,13 @@ Options:
   -h, --help             Show this message and exit.
   -V, --version          Show the version and exit.
   -v, --verbose          Turns on debug-level logging.
+
 ```
 
 #### Check
 ##### `--check`
 
-Using the option will not write any formatted code back to file. It will instead check whether any changes *would* be made. It returns one of three possible exit codes:
+Does not write any formatted code back to file. It will instead check whether any changes *would* be made. It returns one of three possible exit codes:
 
 **0** - indicates **no changes** would be made
 ```
@@ -131,7 +126,7 @@ $ echo "Exit code: $?"
 Exit code: 1
 ```
 
-**123** - indicates there was an **internal error** such as invalid syntax
+**123** - indicates there was an **error** such as invalid syntax
 ```
 $ echo 'include:' | snakefmt --check -            
 [ERROR] L2: In include definition.
@@ -143,7 +138,7 @@ Exit code: 123
 #### Compact diff
 ##### `--compact-diff`
 
-As the name implies, a more compact version of [`--diff`](#diff). Using this option will not write any formatted code back to file. It will instead print a compact diff of how the code looks before and after formatting. The diff is compact as it only prints the lines that will change, with a few lines of surrounding context.
+Does not write any formatted code back to file. It will instead print a compact diff of how the code looks before and after formatting. The diff is compact as it only prints the lines that will change, with a few lines of surrounding context.
 
 ```
 $ echo 'x = 1\ny = 3\n\n\nrule foo:\n\tinput: "foo.txt"' | snakefmt --compact-diff -
@@ -167,7 +162,7 @@ The above example shows that the variable assignments at the beginning of the fi
 #### Diff
 ##### `--diff`
 
-Using this option will not write any formatted code back to file. It will instead print a diff of how the code looks before and after formatting.
+Does not write any formatted code back to file. It will instead print a diff of how the code looks before and after formatting.
 
 ```
 $ echo 'rule foo:\n\tinput: "foo.txt"' | snakefmt --diff -

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/snakemake/snakefmt/python_poetry_package)](https://github.com/snakemake/snakefmt/actions)
+[![codecov](https://codecov.io/gh/snakemake/snakefmt/branch/master/graph/badge.svg)](https://codecov.io/gh/snakemake/snakefmt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+![Python versions](https://img.shields.io/badge/Python%20versions->=3.6-blue)
 
 This repository provides formatting for [Snakemake][snakemake] files. It follows the design and specifications of [Black][black].
 
 ## Install
 
-``` bash
+```shell
 git clone https://github.com/snakemake/snakefmt
-pip install poetry
+python3 -m pip install poetry
 cd snakefmt && poetry install
 poetry shell
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: true # Should Codecov wait for all other statues to pass before sending it's status.
+
+coverage:
+  precision: 2
+  round: down
+  range: "75...100"  # The value range where you want the value to be green
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches:               # branch names that can post comment
+    - "master"
+    - "dev"

--- a/poetry.lock
+++ b/poetry.lock
@@ -102,6 +102,17 @@ version = "1.2.1"
 yaml = ["pyyaml"]
 
 [[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.1"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 category = "main"
 description = "Super-fast, efficiently stored Trie for Python."
 name = "datrie"
@@ -419,6 +430,21 @@ checkqa-mypy = ["mypy (v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8.1"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=3.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
+
+[[package]]
 category = "main"
 description = "Python for Window Extensions"
 marker = "sys_platform == \"win32\""
@@ -625,7 +651,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "bb073da964fa73aa3e6fa2fd2a1974c91c8a3b77eea4a74033b45c6b99523d20"
+content-hash = "bcf937e423691584f724fff51eb79f7215655393415a2525265120dfbc857708"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -667,6 +693,39 @@ colorama = [
 ]
 configargparse = [
     {file = "ConfigArgParse-1.2.1.tar.gz", hash = "sha256:f30736dcd4e00455ffe3087454799ccb7f9b61d765492dd4b35bbcd62379db12"},
+]
+coverage = [
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 datrie = [
     {file = "datrie-0.8.2-cp27-cp27m-macosx_10_7_x86_64.whl", hash = "sha256:53969643e2794c37f024d5edaa42d5e6e2627d9937ddcc18d99128e9df700e4c"},
@@ -800,6 +859,10 @@ pyrsistent = [
 pytest = [
     {file = "pytest-5.4.1-py3-none-any.whl", hash = "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172"},
     {file = "pytest-5.4.1.tar.gz", hash = "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
+    {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
 ]
 pywin32 = [
     {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -146,11 +146,33 @@ version = "0.16"
 
 [[package]]
 category = "dev"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
+optional = false
+python-versions = ">=2.7"
+version = "0.3"
+
+[[package]]
+category = "dev"
 description = "A platform independent file lock."
 name = "filelock"
 optional = false
 python-versions = "*"
 version = "3.0.12"
+
+[[package]]
+category = "dev"
+description = "the modular source code checker: pep8, pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.7.9"
+
+[package.dependencies]
+entrypoints = ">=0.3.0,<0.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.5.0,<2.6.0"
+pyflakes = ">=2.1.0,<2.2.0"
 
 [[package]]
 category = "main"
@@ -274,6 +296,14 @@ traitlets = "*"
 
 [[package]]
 category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
+
+[[package]]
+category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
@@ -286,7 +316,7 @@ description = "The Jupyter Notebook format"
 name = "nbformat"
 optional = false
 python-versions = ">=3.5"
-version = "5.0.5"
+version = "5.0.6"
 
 [package.dependencies]
 ipython-genutils = "*"
@@ -383,6 +413,22 @@ name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.1"
+
+[[package]]
+category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.5.0"
+
+[[package]]
+category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.1.1"
 
 [[package]]
 category = "dev"
@@ -588,11 +634,11 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.8"
+version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -601,7 +647,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.17"
+version = "20.0.18"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -651,7 +697,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "bcf937e423691584f724fff51eb79f7215655393415a2525265120dfbc857708"
+content-hash = "d4f9ec7773d8ff3d8802e45aa8aa5755e8b5369de80bed851c017052db8a238e"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -765,9 +811,17 @@ docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+]
+flake8 = [
+    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
+    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
 ]
 gitdb = [
     {file = "gitdb-4.0.4-py3-none-any.whl", hash = "sha256:ba1132c0912e8c917aa8aa990bee26315064c7b7f171ceaaac0afeb1dc656c6a"},
@@ -805,13 +859,17 @@ jupyter-core = [
     {file = "jupyter_core-4.6.3-py2.py3-none-any.whl", hash = "sha256:a4ee613c060fe5697d913416fc9d553599c05e4492d58fac1192c9a6844abb21"},
     {file = "jupyter_core-4.6.3.tar.gz", hash = "sha256:394fd5dd787e7c8861741880bdf8a00ce39f95de5d18e579c74b882522219e7e"},
 ]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
     {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
 ]
 nbformat = [
-    {file = "nbformat-5.0.5-py3-none-any.whl", hash = "sha256:65a79936a128fd85aef392b7fea520166364037118b6fe3ed52de742d06c4558"},
-    {file = "nbformat-5.0.5.tar.gz", hash = "sha256:f0c47cf93c505cb943e2f131ef32b8ae869292b5f9f279db2bafb35867923f69"},
+    {file = "nbformat-5.0.6-py3-none-any.whl", hash = "sha256:276343c78a9660ab2a63c28cc33da5f7c58c092b3f3a40b6017ae2ce6689320d"},
+    {file = "nbformat-5.0.6.tar.gz", hash = "sha256:049af048ed76b95c3c44043620c17e56bc001329e07f83fec4f177f0e3d7b757"},
 ]
 nodeenv = [
     {file = "nodeenv-1.3.5-py2.py3-none-any.whl", hash = "sha256:5b2438f2e42af54ca968dd1b374d14a1194848955187b0e5e4be1f73813a5212"},
@@ -848,6 +906,14 @@ psutil = [
 py = [
     {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
+    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+]
+pyflakes = [
+    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
+    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -970,12 +1036,12 @@ typed-ast = [
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.8-py2.py3-none-any.whl", hash = "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"},
-    {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.17-py2.py3-none-any.whl", hash = "sha256:00cfe8605fb97f5a59d52baab78e6070e72c12ca64f51151695407cc0eb8a431"},
-    {file = "virtualenv-20.0.17.tar.gz", hash = "sha256:c8364ec469084046c779c9a11ae6340094e8a0bf1d844330fc55c1cefe67c172"},
+    {file = "virtualenv-20.0.18-py2.py3-none-any.whl", hash = "sha256:5021396e8f03d0d002a770da90e31e61159684db2859d0ba4850fbea752aa675"},
+    {file = "virtualenv-20.0.18.tar.gz", hash = "sha256:ac53ade75ca189bc97b6c1d9ec0f1a50efe33cbf178ae09452dcd9fd309013c1"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "The uncompromising Snakemake code formatter"
 authors = ["Michael Hall <michael@mbh.sh>", "Brice Letcher <bletcher@ebi.ac.uk>"]
 license = "MIT"
 readme = "README.md"
-#homepage = ""  # todo
-#repository = ""  # todo
+homepage = "https://github.com/snakemake/snakefmt"
+repository = "https://github.com/snakemake/snakefmt"
 #documentation = ""  # todo
 keywords = ["snakemake", "formatter", "code", "codeformatter", "workflow-management"]
 
@@ -23,6 +23,7 @@ toml = "^0.10.0"
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 pre-commit = "^2.1.1"
+pytest-cov = "^2.8.1"
 
 [tool.poetry.urls]
 "Snakemake Documentation" = "https://snakemake.readthedocs.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ toml = "^0.10.0"
 pytest = "^5.2"
 pre-commit = "^2.1.1"
 pytest-cov = "^2.8.1"
+flake8 = "^3.7.9"
 
 [tool.poetry.urls]
 "Snakemake Documentation" = "https://snakemake.readthedocs.io/"

--- a/snakefmt/diff.py
+++ b/snakefmt/diff.py
@@ -1,5 +1,12 @@
 from typing import List
+from enum import Enum
 import difflib
+
+
+class CheckExitCode(Enum):
+    NO_CHANGE = 0
+    WOULD_CHANGE = 1
+    INTERNAL_ERROR = 123
 
 
 class Diff:

--- a/snakefmt/diff.py
+++ b/snakefmt/diff.py
@@ -1,0 +1,29 @@
+from typing import List
+import difflib
+
+
+class Diff:
+    def __init__(self, compact: bool = True, context_lines: int = 3):
+        self.compact = compact
+        self.context_lines = context_lines
+
+    @staticmethod
+    def _splitlines(string: str) -> List[str]:
+        return string.splitlines(keepends=True)
+
+    def compare(self, original: str, new: str) -> str:
+        original_lines = self._splitlines(original)
+        new_lines = self._splitlines(new)
+
+        if self.compact:
+            diff = difflib.unified_diff(
+                original_lines,
+                new_lines,
+                n=self.context_lines,
+                fromfile="original",
+                tofile="new",
+            )
+        else:
+            diff = difflib.ndiff(original_lines, new_lines)
+
+        return "".join(diff)

--- a/snakefmt/diff.py
+++ b/snakefmt/diff.py
@@ -27,3 +27,7 @@ class Diff:
             diff = difflib.ndiff(original_lines, new_lines)
 
         return "".join(diff)
+
+    @staticmethod
+    def is_changed(original: str, new: str) -> bool:
+        return original != new

--- a/snakefmt/diff.py
+++ b/snakefmt/diff.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 from enum import Enum
 import difflib
 
@@ -6,7 +6,17 @@ import difflib
 class CheckExitCode(Enum):
     NO_CHANGE = 0
     WOULD_CHANGE = 1
-    INTERNAL_ERROR = 123
+    ERROR = 123
+
+    def __eq__(self, other: Union[int, "CheckExitCode"]) -> bool:
+        if self.__class__ is other.__class__:
+            return self.name == other.name and self.value == other.value
+        elif isinstance(other, int):
+            return self.value == other
+        else:
+            raise NotImplementedError(
+                f"Equality between CheckExitCode and {type(other)} is not implemented."
+            )
 
 
 class Diff:

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -146,7 +146,7 @@ class Formatter(Parser):
             result = f"{val}{comments}\n"
         else:
             result = f"{val},{comments}\n"
-        if parameter.has_key():
+        if parameter.has_key():  # noqa: W601
             result = f"{parameter.key}={result}"
         result = f"{used_indent}{result}"
         return result
@@ -159,7 +159,7 @@ class Formatter(Parser):
         p_class = parameters.__class__
         single_param = issubclass(p_class, SingleParam)
         inline_fmting = single_param
-        # single parameter formatting cancelled if we are in rule-like context and param is not inline
+        # Cancel single param formatting if in rule-like context and param not inline
         if in_rule and p_class is not RuleInlineSingleParam:
             inline_fmting = False
 
@@ -188,4 +188,4 @@ class Formatter(Parser):
             self.first = False
 
     def rule_like(self, kwrd):
-        return kwrd is not "" and kwrd.split()[0] in rule_like_formatted
+        return kwrd != "" and kwrd.split()[0] in rule_like_formatted

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -16,7 +16,7 @@ possibly_named_keywords = {"rule", "checkpoint", "subworkflow"}
 possibly_duplicated_keywords = {"include", "ruleorder", "localrules"}
 
 """
-Token parsing 
+Token parsing
 """
 QUOTES = {'"', "'"}
 BRACKETS_OPEN = {"(", "[", "{"}
@@ -105,13 +105,19 @@ class Syntax:
             if self.keyword_name in possibly_named_keywords:
                 if self.token.type != tokenize.NAME:
                     raise NamedKeywordError(
-                        f"{self.line_nb}Invalid name {self.token.string} for '{self.keyword_name}'"
+                        (
+                            f"{self.line_nb}Invalid name {self.token.string} "
+                            f"for '{self.keyword_name}'"
+                        )
                     )
                 self.keyword_name += f" {self.token.string}"
                 self.token = next(snakefile)
         if not is_colon(self.token):
             raise SyntaxError(
-                f"{self.line_nb}Colon (not '{self.token.string}') expected after '{self.keyword_name}'"
+                (
+                    f"{self.line_nb}Colon (not '{self.token.string}') expected after "
+                    f"'{self.keyword_name}'"
+                )
             )
         self.token = next(snakefile)
 
@@ -148,7 +154,10 @@ class KeywordSyntax(Syntax):
         if incident_context is not None:
             if self.token.type != tokenize.NEWLINE:
                 raise SyntaxError(
-                    f"{self.line_nb}Newline expected after keyword '{self.keyword_name}'"
+                    (
+                        f"{self.line_nb}Newline expected after keyword "
+                        f"'{self.keyword_name}'"
+                    )
                 )
             if not from_python:
                 incident_context.add_processed_keyword(self.token, self.keyword_name)
@@ -297,7 +306,10 @@ class ParameterSyntax(Syntax):
                     self.in_lambda = True
                 if self.incident_vocab.recognises(cur_param.value):
                     raise InvalidParameterSyntax(
-                        f"{self.line_nb}Over-indented recognised keyword found: '{cur_param.value}'"
+                        (
+                            f"{self.line_nb}Over-indented recognised keyword found: "
+                            f"'{cur_param.value}'"
+                        )
                     )
             cur_param.add_elem(self.token)
         return cur_param
@@ -306,7 +318,7 @@ class ParameterSyntax(Syntax):
         if not parameter.has_value() and skip_empty:
             return
 
-        if parameter.has_key():
+        if parameter.has_key():  # noqa: W601
             self.keyword_params.append(parameter)
         else:
             self.positional_params.append(parameter)
@@ -327,11 +339,17 @@ class SingleParam(ParameterSyntax):
 
         if self.num_params() > 1:
             raise TooManyParameters(
-                f"{self.line_nb}{self.keyword_name} definition expects a single parameter"
+                (
+                    f"{self.line_nb}{self.keyword_name} definition expects a single "
+                    f"parameter"
+                )
             )
         if not len(self.keyword_params) == 0:
             raise InvalidParameter(
-                f"{self.line_nb}{self.keyword_name} definition requires a positional (not key/value) parameter"
+                (
+                    f"{self.line_nb}{self.keyword_name} definition requires a "
+                    f"positional (not key/value) parameter"
+                )
             )
 
 
@@ -361,5 +379,8 @@ class NoKeywordParamList(ParameterSyntax):
 
         if len(self.keyword_params) > 0:
             raise InvalidParameterSyntax(
-                f"{self.line_nb}{self.keyword_name} definition does not accept key/value parameters"
+                (
+                    f"{self.line_nb}{self.keyword_name} definition does not accept "
+                    f"key/value parameters"
+                )
             )

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -16,7 +16,10 @@ from snakefmt.parser.parser import Snakefile
 sys.tracebacklimit = 0  # Disable exceptions tracebacks
 
 PathLike = Union[Path, str]
-DEFAULT_EXCLUDES = r"(\.snakemake|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)"
+DEFAULT_EXCLUDES = (
+    r"(\.snakemake|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|"
+    r"buck-out|build|dist)"
+)
 DEFAULT_INCLUDES = r"(\.smk$|^Snakefile)"
 
 

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -333,7 +333,7 @@ def main(
 
     if check:
         if files_with_errors > 0:
-            logging.info(f"{files_with_errors} file(s) contain errors 🤕")
+            logging.info(f"{files_with_errors} file(s) contains errors 🤕")
             ctx.exit(CheckExitCode.INTERNAL_ERROR.value)
         elif files_changed > 0:
             logging.info(f"{files_changed} file(s) would be changed 😬")

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -227,9 +227,9 @@ def main(
     sources: Set[PathLike] = set()
     root = Path()
     gitignore = get_gitignore(Path())
-    for s in src:
-        path = Path(s)
-        if s == "-" or path.is_file():
+    for path in src:
+        path = Path(path)
+        if path.name == "-" or path.is_file():
             # if a file was explicitly given, we don't care about its extension
             sources.add(path)
         elif path.is_dir():
@@ -239,15 +239,15 @@ def main(
                 )
             )
         else:
-            logging.warning(f"ignoring invalid path: {s}")
+            logging.warning(f"ignoring invalid path: {path}")
 
-    for s in sources:
-        if s.name == "-":
+    for path in sources:
+        if path.name == "-":
             logging.info("Formatting from stdin")
-            s = sys.stdin
+            path = sys.stdin
         else:
-            logging.info(f"Formatting {s}")
-        snakefile = Snakefile(s)
+            logging.info(f"Formatting {path}")
+        snakefile = Snakefile(path)
         formatter = Formatter(snakefile, line_length=line_length, black_config=config)
         print(formatter.get_formatted())
 

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -145,8 +145,7 @@ def get_snakefiles_in_dir(
         f"Don't write the files back, just return the status. Return code "
         f"{CheckExitCode.NO_CHANGE.value} means nothing would change. Return code "
         f"{CheckExitCode.WOULD_CHANGE.value} means some files would be reformatted. "
-        f"Return code {CheckExitCode.INTERNAL_ERROR.value} means there was an internal "
-        f"error."
+        f"Return code {CheckExitCode.ERROR.value} means there was an error."
     ),
 )
 @click.option(
@@ -334,7 +333,7 @@ def main(
     if check:
         if files_with_errors > 0:
             logging.info(f"{files_with_errors} file(s) contains errors 🤕")
-            ctx.exit(CheckExitCode.INTERNAL_ERROR.value)
+            ctx.exit(CheckExitCode.ERROR.value)
         elif files_changed > 0:
             logging.info(f"{files_changed} file(s) would be changed 😬")
             ctx.exit(CheckExitCode.WOULD_CHANGE.value)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -78,3 +78,33 @@ class TestCompare:
         )
 
         assert actual == expected
+
+
+class TestIsChanged:
+    def test_same_strings_compact_returns_false(self):
+        original = "foo\n    bar"
+        new = "foo\n    bar"
+        diff = Diff(compact=True)
+
+        assert not diff.is_changed(original, new)
+
+    def test_same_strings_non_compact_returns_false(self):
+        original = "foo\n    bar"
+        new = "foo\n    bar"
+        diff = Diff(compact=False)
+
+        assert not diff.is_changed(original, new)
+
+    def test_different_strings_compact_returns_false(self):
+        original = "foo\n    bar"
+        new = "foo\n    baz"
+        diff = Diff(compact=True)
+
+        assert diff.is_changed(original, new)
+
+    def test_different_strings_non_compact_returns_false(self):
+        original = "foo\n    bar\n"
+        new = "foo\n    bar"
+        diff = Diff(compact=True)
+
+        assert diff.is_changed(original, new)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,4 +1,39 @@
-from snakefmt.diff import Diff
+import pytest
+
+from snakefmt.diff import Diff, CheckExitCode
+
+
+class TestCheckExitCode:
+    def test_equality_two_enums(self):
+        actual = CheckExitCode.WOULD_CHANGE
+        other = CheckExitCode.WOULD_CHANGE
+
+        assert actual == other
+
+    def test_equality_two_different_enums(self):
+        actual = CheckExitCode.WOULD_CHANGE
+        other = CheckExitCode.ERROR
+
+        assert actual != other
+
+    def test_equality_one_enum_one_int_same_value(self):
+        actual = CheckExitCode.NO_CHANGE
+        other = 0
+
+        assert actual == other
+
+    def test_equality_one_enum_one_int_different_value(self):
+        actual = CheckExitCode.ERROR
+        other = 0
+
+        assert actual != other
+
+    def test_equality_one_enum_one_float_raises_error(self):
+        actual = CheckExitCode.ERROR
+        other = 123.0
+
+        with pytest.raises(NotImplementedError):
+            actual == other
 
 
 class TestCompare:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,80 @@
+from snakefmt.diff import Diff
+
+
+class TestCompare:
+    def test_empty_strings_returns_empty(self):
+        original = ""
+        new = ""
+        diff = Diff()
+
+        actual = diff.compare(original, new)
+        expected = ""
+
+        assert actual == expected
+
+    def test_same_strings_returns_empty(self):
+        original = "foo\n    bar"
+        new = "foo\n    bar"
+        diff = Diff()
+
+        actual = diff.compare(original, new)
+        expected = ""
+
+        assert actual == expected
+
+    def test_strings_differ_by_one_char_compact(self):
+        original = "foo\n    bar"
+        new = "foo\n    baz"
+        diff = Diff(compact=True)
+
+        actual = diff.compare(original, new)
+        expected = (
+            "--- original\n" "+++ new\n" "@@ -1,2 +1,2 @@\n" " foo\n" "-    bar+    baz"
+        )
+
+        assert actual == expected
+
+    def test_strings_differ_by_one_empty_line_compact(self):
+        original = "foo\n    bar\n"
+        new = "foo\n    baz"
+        diff = Diff(compact=True)
+
+        actual = diff.compare(original, new)
+        expected = (
+            "--- original\n"
+            "+++ new\n"
+            "@@ -1,2 +1,2 @@\n"
+            " foo\n"
+            "-    bar\n"
+            "+    baz"
+        )
+
+        assert actual == expected
+
+    def test_strings_differ_by_one_char_non_compact(self):
+        original = "foo\n    bar"
+        new = "foo\n    baz"
+        diff = Diff(compact=False)
+
+        actual = diff.compare(original, new)
+        expected = "  foo\n-     bar?       ^\n+     baz?       ^\n"
+
+        assert actual == expected
+
+    def test_strings_differ_compact_only_context_lines_returned(self):
+        original = "line0\nline1\nline2\nfoo\n    bar\nline3\nline4\nline5\nline6"
+        new = "line0\nline1\nline2\nfoo\n    baz\nline3\nline4\nline5\nline6"
+        diff = Diff(compact=True, context_lines=1)
+
+        actual = diff.compare(original, new)
+        expected = (
+            "--- original\n"
+            "+++ new\n"
+            "@@ -4,3 +4,3 @@\n"
+            " foo\n"
+            "-    bar\n"
+            "+    baz\n"
+            " line3\n"
+        )
+
+        assert actual == expected

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -82,8 +82,8 @@ class TestCompare:
 
 class TestIsChanged:
     def test_same_strings_compact_returns_false(self):
-        original = "foo\n    bar"
-        new = "foo\n    bar"
+        original = "foo\n    bar\n\n"
+        new = "foo\n    bar\n\n"
         diff = Diff(compact=True)
 
         assert not diff.is_changed(original, new)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -95,7 +95,7 @@ class TestPythonFormatting:
         """
         formatter = setup_formatter("#configfile: 'foo.yaml'")
 
-        actual = formatter.get_formatted()
+        formatter.get_formatted()
         mock_method.assert_called_once()
 
     def test_python_code_with_multi_indent_passes(self):
@@ -186,7 +186,10 @@ class TestPythonFormatting:
         assert formatter.get_formatted() == snakecode
 
     def test_line_wrapped_python_code_outside_rule(self):
-        content = "list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\ninclude: snakefile"
+        content = (
+            "list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+            "include: snakefile"
+        )
         line_length = 30
         formatter = setup_formatter(content, line_length=line_length)
 
@@ -203,7 +206,11 @@ class TestPythonFormatting:
 
     @pytest.mark.xfail(reason="Indenting out by one for elements in list")
     def test_line_wrapped_python_code_inside_rule(self):
-        content = f"rule a:\n{TAB}input:\n{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        content = (
+            f"rule a:\n"
+            f"{TAB}input:\n"
+            f"{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        )
         line_length = 30
         formatter = setup_formatter(content, line_length=line_length)
 
@@ -313,7 +320,7 @@ class TestSimpleParamFormatting:
 
     def test_lambda_function_as_parameter(self):
         stream = StringIO(
-            """rule a: 
+            """rule a:
                 input: lambda wildcards: foo(wildcards)"""
         )
         smk = Snakefile(stream)
@@ -390,7 +397,7 @@ class TestCommaParamFormatting:
             f'{TAB * 2}"foo.txt",\n'
             f"{TAB * 1}params:\n"
             f"{TAB * 2}"
-            'obs=lambda w, input: ["{}={}".format(s, f) for s, f in zip(get_group_aliases(w), input.obs)],\n'
+            'obs=lambda w, input: ["{}={}".format(s, f) for s, f in zip(get_group_aliases(w), input.obs)],\n'  # noqa: E501  due to readability of test
             f"{TAB * 2}p2=2,\n"
         )
         formatter = setup_formatter(snakefile)
@@ -529,8 +536,11 @@ rule all:
 # Rules
 # ======================================================
 rule all:
-    input: 
+    input:
         output_files,
 
 
-# https://github.com/nanoporetech/taiyaki/blob/master/docs/walkthrough.rst#bam-of-mapped-basecalls"""
+# https://github.com/nanoporetech/taiyaki/blob/master/docs/walkthrough.rst#bam-of-mapped-basecalls
+"""
+
+        assert actual == expected

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,5 +1,5 @@
 """
-Completeness tests: checks that the grammar used is a bijection of the snakemake grammar.
+Completeness tests: checks that the grammar used is a bijection of the snakemake grammar
     To use the latest snakemake grammar, run `poetry update snakemake` from this repo
 """
 from snakemake import parser

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -53,7 +53,8 @@ class TestKeywordSyntax:
 
     def test_implicitly_unrecognised_keyword(self):
         """
-        The keyword lives in the 'base' space, so could also be interpreted as Python code.
+        The keyword lives in the 'base' space, so could also be interpreted as Python
+        code.
         In that case black will complain of invalid python and not format it.
         """
         with pytest.raises(InvalidPython):

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -336,19 +336,21 @@ list_of_lots_of_things = [
 
         assert actual_content == expected_content
 
-    def test_src_dir_is_searched_for_files(self, cli_runner, tmp_path):
-        content = 'include: "a"'
-        snakedir = tmp_path / "workflows"
-        snakedir.mkdir()
-        snakefile = snakedir / "Snakefile"
-        snakefile.write_text(content)
-        params = [str(tmp_path)]
+    def test_src_dir_is_searched_for_files(self, cli_runner):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = 'include: "a"'
+            abs_tmpdir = Path(tmpdir).resolve()
+            snakedir = abs_tmpdir / "workflows"
+            snakedir.mkdir()
+            snakefile = snakedir / "Snakefile"
+            snakefile.write_text(content)
+            params = [str(tmpdir)]
 
-        cli_runner.invoke(main, params)
-        expected_contents = content + "\n"
-        actual_contents = snakefile.read_text()
+            cli_runner.invoke(main, params)
+            expected_contents = content + "\n"
+            actual_contents = snakefile.read_text()
 
-        assert actual_contents == expected_contents
+            assert actual_contents == expected_contents
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -137,7 +137,7 @@ list_of_lots_of_things = [
         params = ["--check", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-        expected = CheckExitCode.NO_CHANGE.value
+        expected = CheckExitCode.NO_CHANGE
 
         assert actual.exit_code == expected
 
@@ -146,7 +146,7 @@ list_of_lots_of_things = [
         params = ["--check", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-        expected = CheckExitCode.WOULD_CHANGE.value
+        expected = CheckExitCode.WOULD_CHANGE
 
         assert actual.exit_code == expected
 
@@ -155,7 +155,7 @@ list_of_lots_of_things = [
         params = ["--check", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-        expected = CheckExitCode.INTERNAL_ERROR.value
+        expected = CheckExitCode.ERROR
 
         assert actual.exit_code == expected
 
@@ -167,7 +167,7 @@ list_of_lots_of_things = [
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.WOULD_CHANGE.value
+        expected_exit_code = CheckExitCode.WOULD_CHANGE
         assert result.exit_code == expected_exit_code
 
         expected_contents = content
@@ -184,7 +184,7 @@ list_of_lots_of_things = [
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.NO_CHANGE.value
+        expected_exit_code = CheckExitCode.NO_CHANGE
         assert result.exit_code == expected_exit_code
 
     def test_check_two_files_one_will_change(self, cli_runner, tmp_path):
@@ -198,7 +198,7 @@ list_of_lots_of_things = [
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.WOULD_CHANGE.value
+        expected_exit_code = CheckExitCode.WOULD_CHANGE
         assert result.exit_code == expected_exit_code
 
     def test_check_two_files_one_has_errors(self, cli_runner, tmp_path):
@@ -212,7 +212,7 @@ list_of_lots_of_things = [
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.INTERNAL_ERROR.value
+        expected_exit_code = CheckExitCode.ERROR
         assert result.exit_code == expected_exit_code
 
     def test_diff_works_as_expected(self, cli_runner):
@@ -303,7 +303,7 @@ list_of_lots_of_things = [
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.WOULD_CHANGE.value
+        expected_exit_code = CheckExitCode.WOULD_CHANGE
         assert result.exit_code == expected_exit_code
         assert result.output == ""
 

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -252,6 +252,27 @@ list_of_lots_of_things = [
 
         assert result.output == expected_output
 
+    def test_compact_diff_and_diff_given_runs_compact_diff(self, cli_runner):
+        stdin = "include: 'a'\n"
+        params = ["--compact-diff", "--diff", "-"]
+
+        result = cli_runner.invoke(main, params, input=stdin)
+        expected_exit_code = 0
+
+        assert result.exit_code == expected_exit_code
+
+        expected_output = (
+            "=====> Diff for stdin <=====\n"
+            "\n"
+            "--- original\n"
+            "+++ new\n"
+            "@@ -1 +1 @@\n"
+            "-include: 'a'\n"
+            '+include: "a"\n\n'
+        )
+
+        assert result.output == expected_output
+
     def test_diff_does_not_format_file(self, cli_runner, tmp_path):
         content = "include: 'a'\nlist_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8]"
         snakefile = tmp_path / "Snakefile"
@@ -310,6 +331,20 @@ list_of_lots_of_things = [
         expected_content = content + "\n"
 
         assert actual_content == expected_content
+
+    def test_src_dir_is_searched_for_files(self, cli_runner, tmp_path):
+        content = 'include: "a"'
+        snakedir = tmp_path / "workflows"
+        snakedir.mkdir()
+        snakefile = snakedir / "Snakefile"
+        snakefile.write_text(content)
+        params = [str(tmp_path)]
+
+        result = cli_runner.invoke(main, params)
+
+        expected_contents = content + "\n"
+        actual_contents = snakefile.read_text()
+        assert actual_contents == expected_contents
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -107,7 +107,11 @@ list_of_lots_of_things = [
 
     @pytest.mark.xfail(reason="Indenting out by one for elements in list")
     def test_config_adherence_for_code_inside_rules(self, cli_runner, tmp_path):
-        stdin = f"rule a:\n{TAB}input:\n{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        stdin = (
+            f"rule a:\n"
+            f"{TAB}input:\n"
+            f"{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        )
         line_length = 30
         config = tmp_path / "pyproject.toml"
         config.write_text(f"[tool.snakefmt]\nline_length = {line_length}\n")
@@ -310,7 +314,7 @@ list_of_lots_of_things = [
         params = [str(file)]
         expected_stat = file.stat()
 
-        result = cli_runner.invoke(main, params)
+        cli_runner.invoke(main, params)
         actual_stat = file.stat()
 
         assert actual_stat == expected_stat
@@ -322,7 +326,7 @@ list_of_lots_of_things = [
         params = [str(file)]
         original_stat = file.stat()
 
-        result = cli_runner.invoke(main, params)
+        cli_runner.invoke(main, params)
         actual_stat = file.stat()
 
         assert actual_stat != original_stat
@@ -340,10 +344,10 @@ list_of_lots_of_things = [
         snakefile.write_text(content)
         params = [str(tmp_path)]
 
-        result = cli_runner.invoke(main, params)
-
+        cli_runner.invoke(main, params)
         expected_contents = content + "\n"
         actual_contents = snakefile.read_text()
+
         assert actual_contents == expected_contents
 
 
@@ -364,7 +368,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
 
         assert actual_default_map == expected_default_map
 
-    def test_no_value_passed_and_pyproject_present_but_empty_changes_nothing_returns_pyproject_path(
+    def test_pyproject_present_but_empty_changes_nothing_returns_pyproject_path(
         self, tmpdir
     ):
         os.chdir(tmpdir)


### PR DESCRIPTION
This PR closes #5 and #6 

### Added
- `--check` option to allow checking whether any changes would be made and returning an exit code relevant to the result [#5]
- `--diff` and `--compact-diff` options to allow checking what changes would be made without writing back to file [#6]
- `Diff` class that is used for dealing with the check and diff options.
- Various tests to increase coverage
- Badges! :tada: 

### Changed
- Writing back to file when formatting files. (We were just printing to screen until now).
- Full usage in README with new options
- Documenting check and diff options in README
- flake8 fixes in the test directory so now the CI runs flake8 on the entire project.