### PR TITLE
Bugfixes and refactoring

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
 max-line-length = 88
 # the default ignores minus E704
-ignore = E121,E123,E126,E226,E24,W503,W504
+ignore = E121,E123,E126,E226,E203,E24,W503,W504
+

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -122,7 +122,7 @@ class Formatter(Parser):
     ) -> str:
         if inline_formatting:
             target_indent = 0
-        comments = "\n{i}".format(i=target_indent).join(parameter.comments)
+        comments = f"\n{TAB * target_indent}".join(parameter.comments)
         val = str(parameter)
 
         try:

--- a/snakefmt/parser/parser.py
+++ b/snakefmt/parser/parser.py
@@ -48,6 +48,7 @@ class Parser(ABC):
         )
         self.context_stack = [self.grammar]
         self.snakefile = snakefile
+        from_python = False
 
         status = self.context.get_next_queriable(self.snakefile)
         self.buffer = status.buffer
@@ -70,6 +71,7 @@ class Parser(ABC):
                 self.flush_buffer(from_python)
                 status = self.process_keyword(status, from_python)
             else:
+                from_python = False
                 if not self.context.accepts_python_code and not keyword[0] == "#":
                     raise SyntaxError(
                         f"L{status.token.start[0]}: Unrecognised keyword '{keyword}' "
@@ -80,7 +82,7 @@ class Parser(ABC):
                     status = self.context.get_next_queriable(self.snakefile)
                     self.buffer += status.buffer
             self.context.cur_indent = status.indent
-        self.flush_buffer()
+        self.flush_buffer(from_python)
 
     @property
     def vocab(self) -> Vocabulary:

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -13,7 +13,7 @@ from snakefmt.exceptions import (
 )
 
 possibly_named_keywords = {"rule", "checkpoint", "subworkflow"}
-possibly_duplicated_keywords = {"include", "ruleorder", "localrules"}
+possibly_duplicated_keywords = {"include", "ruleorder", "localrules", "configfile"}
 
 """
 Token parsing

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -59,7 +59,7 @@ spacing_triggers = {
 }
 
 
-def operator_skip_spacing(prev_token: Token, token: Token):
+def operator_skip_spacing(prev_token: Token, token: Token) -> bool:
     if prev_token.type != tokenize.OP and token.type != tokenize.OP:
         return False
     elif (
@@ -193,7 +193,7 @@ class KeywordSyntax(Syntax):
     def effective_indent(self) -> int:
         return max(0, self.cur_indent - self.target_indent)
 
-    def get_next_queriable(self, snakefile) -> Syntax.Status:
+    def get_next_queriable(self, snakefile: TokenIterator) -> Syntax.Status:
         buffer = ""
         newline = False
         pythonable = False
@@ -344,7 +344,7 @@ class ParameterSyntax(Syntax):
         if not parameter.has_value() and skip_empty:
             return
 
-        if parameter.has_a_key():  # noqa: W601
+        if parameter.has_a_key():
             self.keyword_params.append(parameter)
             self.latest_pushed_param = self.keyword_params[-1]
         else:

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -318,7 +318,7 @@ class ParameterSyntax(Syntax):
         if not parameter.has_value() and skip_empty:
             return
 
-        if parameter.has_key():  # noqa: W601
+        if parameter.has_a_key():  # noqa: W601
             self.keyword_params.append(parameter)
         else:
             self.positional_params.append(parameter)

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -235,6 +235,7 @@ class ParameterSyntax(Syntax):
         self.incident_vocab = incident_vocab
         self._brackets = list()
         self.found_newline, self.in_lambda = False, False
+        self.latest_pushed_param = None
 
         self.parse_params(snakefile)
 
@@ -288,7 +289,11 @@ class ParameterSyntax(Syntax):
             if cur_param.has_value():
                 cur_param.add_elem(self.token)
         elif token_type == tokenize.COMMENT:
-            cur_param.comments.append(" " + self.token.string)
+            if str(cur_param) == "":
+                target = self.latest_pushed_param.comments
+            else:
+                target = cur_param.comments
+            target.append(" " + self.token.string)
         elif is_equal_sign(self.token) and not self.in_brackets:
             cur_param.to_key_val_mode(self.token)
         elif is_comma_sign(self.token) and not self.in_brackets and not self.in_lambda:
@@ -320,8 +325,10 @@ class ParameterSyntax(Syntax):
 
         if parameter.has_a_key():  # noqa: W601
             self.keyword_params.append(parameter)
+            self.latest_pushed_param = self.keyword_params[-1]
         else:
             self.positional_params.append(parameter)
+            self.latest_pushed_param = self.positional_params[-1]
 
     def num_params(self):
         return len(self.keyword_params) + len(self.positional_params)

--- a/snakefmt/types.py
+++ b/snakefmt/types.py
@@ -20,7 +20,13 @@ class Parameter:
         self.comments = list()
         self.len = 0
 
-    def has_key(self) -> bool:
+    def __repr__(self):
+        if self.has_a_key():
+            return f"{self.key}={self.value}"
+        else:
+            return self.value
+
+    def has_a_key(self) -> bool:
         return len(self.key) > 0
 
     def has_value(self) -> bool:

--- a/snakefmt/types.py
+++ b/snakefmt/types.py
@@ -1,10 +1,16 @@
 import tokenize
-from typing import Iterator
-from collections import namedtuple
+from typing import Iterator, NamedTuple, Tuple
 
 from snakefmt.exceptions import InvalidParameterSyntax
 
-Token = namedtuple
+
+class Token(NamedTuple):
+    type: int
+    string: str = ""
+    start: Tuple[int, int] = (-1, -1)
+    end: Tuple[int, int] = (-1, -1)
+
+
 TokenIterator = Iterator[Token]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "pytester"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,10 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
 pytest_plugins = "pytester"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,232 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+import click
+import black
+import pytest
+
+from tests import setup_formatter
+from snakefmt.snakefmt import read_snakefmt_defaults_from_pyproject_toml
+from snakefmt.exceptions import InvalidBlackConfiguration, MalformattedToml
+
+
+class TestReadSnakefmtDefaultsFromPyprojectToml:
+    def test_no_value_passed_and_no_pyproject_changes_nothing(self, tmpdir):
+        os.chdir(tmpdir)
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        return_val = read_snakefmt_defaults_from_pyproject_toml(ctx, param, value)
+
+        assert return_val is None
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict()
+
+        assert actual_default_map == expected_default_map
+
+    def test_pyproject_present_but_empty_changes_nothing_returns_pyproject_path(
+        self, tmpdir
+    ):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.touch()
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = None
+
+        assert actual_config_path == expected_config_path
+        assert ctx.default_map == dict()
+
+    def test_no_value_passed_and_pyproject_present_changes_default_line_length(
+        self, tmpdir
+    ):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("[tool.snakefmt]\nline_length = 4")
+        default_map = dict(line_length=88)
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(line_length=4)
+
+        assert actual_default_map == expected_default_map
+
+    def test_no_value_passed_and_pyproject_present_unknown_param_adds_to_default_map(
+        self, tmpdir
+    ):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("[tool.snakefmt]\nfoo = true")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_value_passed_reads_from_path(self, tmpdir):
+        os.chdir(tmpdir)
+        pyproject = Path("snakefmt.toml")
+        pyproject.write_text("[tool.snakefmt]\nfoo = true")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value=str(pyproject)
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_value_passed_but_default_map_is_None_still_updates_defaults(self, tmpdir):
+        os.chdir(tmpdir)
+        pyproject = Path("snakefmt.toml")
+        pyproject.write_text("[tool.snakefmt]\nfoo = true")
+        default_map = None
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = str(pyproject)
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_value_passed_in_overrides_pyproject(self, tmpdir):
+        os.chdir(tmpdir)
+        snakefmt_config = Path("snakefmt.toml")
+        snakefmt_config.write_text("[tool.snakefmt]\nfoo = true")
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("[tool.snakefmt]\n\nfoo = false\nline_length = 90")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = str(snakefmt_config)
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(snakefmt_config)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_malformatted_toml_raises_error(self, tmpdir):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("foo:bar,baz\n{dict}&&&&")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        with pytest.raises(click.FileError):
+            read_snakefmt_defaults_from_pyproject_toml(ctx, param, value)
+
+
+class TestReadBlackConfig:
+    def test_config_doesnt_exist_raises_error(self, tmp_path):
+        formatter = setup_formatter("")
+        path = tmp_path / "config.toml"
+        with pytest.raises(FileNotFoundError):
+            formatter.read_black_config(path)
+
+    def test_config_exists_but_no_black_settings(self, tmp_path):
+        formatter = setup_formatter("")
+        path = tmp_path / "config.toml"
+        path.write_text("[tool.snakefmt]\nline_length = 99")
+
+        actual = formatter.read_black_config(path)
+        expected = black.FileMode(line_length=formatter.line_length)
+
+        assert actual == expected
+
+    def test_config_exists_with_black_settings(self, tmp_path):
+        formatter = setup_formatter("")
+        path = tmp_path / "config.toml"
+        black_line_length = 9
+        path.write_text(f"[tool.black]\nline_length = {black_line_length}")
+
+        actual = formatter.read_black_config(path)
+        expected = black.FileMode(line_length=black_line_length)
+
+        assert actual == expected
+
+    def test_config_exists_with_no_line_length_uses_snakefmt_line_length(
+        self, tmp_path
+    ):
+        line_length = 9
+        formatter = setup_formatter("", line_length=line_length)
+        path = tmp_path / "config.toml"
+        path.write_text("[tool.black]\nstring_normalization = false")
+
+        actual = formatter.read_black_config(path)
+        expected = black.FileMode(line_length=line_length, string_normalization=False)
+
+        assert actual == expected
+
+    def test_config_exists_with_invalid_black_options_raises_error(self, tmp_path):
+        formatter = setup_formatter("")
+        path = tmp_path / "config.toml"
+        path.write_text("[tool.black]\nfoo = false")
+
+        with pytest.raises(InvalidBlackConfiguration) as error:
+            formatter.read_black_config(path)
+
+        assert error.match("unexpected keyword argument")
+
+    def test_malformatted_toml_raises_error(self, tmp_path):
+        formatter = setup_formatter("")
+        path = tmp_path / "config.toml"
+        path.write_text("[tool.black]\n{key}: I am not json:\n or yaml = false")
+
+        with pytest.raises(MalformattedToml) as error:
+            formatter.read_black_config(path)
+
+        assert error.match("invalid character")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from unittest import mock
 
@@ -12,8 +11,7 @@ from snakefmt.exceptions import InvalidBlackConfiguration, MalformattedToml
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:
-    def test_no_value_passed_and_no_pyproject_changes_nothing(self, tmpdir):
-        os.chdir(tmpdir)
+    def test_no_value_passed_and_no_pyproject_changes_nothing(self, testdir):
         default_map = dict()
         ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
         param = mock.MagicMock()
@@ -29,9 +27,8 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         assert actual_default_map == expected_default_map
 
     def test_pyproject_present_but_empty_changes_nothing_returns_pyproject_path(
-        self, tmpdir
+        self, testdir
     ):
-        os.chdir(tmpdir)
         pyproject = Path("pyproject.toml")
         pyproject.touch()
         default_map = dict()
@@ -48,9 +45,8 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         assert ctx.default_map == dict()
 
     def test_no_value_passed_and_pyproject_present_changes_default_line_length(
-        self, tmpdir
+        self, testdir
     ):
-        os.chdir(tmpdir)
         pyproject = Path("pyproject.toml")
         pyproject.write_text("[tool.snakefmt]\nline_length = 4")
         default_map = dict(line_length=88)
@@ -71,9 +67,8 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         assert actual_default_map == expected_default_map
 
     def test_no_value_passed_and_pyproject_present_unknown_param_adds_to_default_map(
-        self, tmpdir
+        self, testdir
     ):
-        os.chdir(tmpdir)
         pyproject = Path("pyproject.toml")
         pyproject.write_text("[tool.snakefmt]\nfoo = true")
         default_map = dict()
@@ -93,8 +88,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
 
         assert actual_default_map == expected_default_map
 
-    def test_value_passed_reads_from_path(self, tmpdir):
-        os.chdir(tmpdir)
+    def test_value_passed_reads_from_path(self, testdir):
         pyproject = Path("snakefmt.toml")
         pyproject.write_text("[tool.snakefmt]\nfoo = true")
         default_map = dict()
@@ -113,8 +107,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
 
         assert actual_default_map == expected_default_map
 
-    def test_value_passed_but_default_map_is_None_still_updates_defaults(self, tmpdir):
-        os.chdir(tmpdir)
+    def test_value_passed_but_default_map_is_None_still_updates_defaults(self, testdir):
         pyproject = Path("snakefmt.toml")
         pyproject.write_text("[tool.snakefmt]\nfoo = true")
         default_map = None
@@ -134,8 +127,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
 
         assert actual_default_map == expected_default_map
 
-    def test_value_passed_in_overrides_pyproject(self, tmpdir):
-        os.chdir(tmpdir)
+    def test_value_passed_in_overrides_pyproject(self, testdir):
         snakefmt_config = Path("snakefmt.toml")
         snakefmt_config.write_text("[tool.snakefmt]\nfoo = true")
         pyproject = Path("pyproject.toml")
@@ -157,8 +149,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
 
         assert actual_default_map == expected_default_map
 
-    def test_malformatted_toml_raises_error(self, tmpdir):
-        os.chdir(tmpdir)
+    def test_malformatted_toml_raises_error(self, testdir):
         pyproject = Path("pyproject.toml")
         pyproject.write_text("foo:bar,baz\n{dict}&&&&")
         default_map = dict()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,64 @@ import black
 import pytest
 
 from tests import setup_formatter
-from snakefmt.snakefmt import read_snakefmt_defaults_from_pyproject_toml
+from snakefmt.formatter import TAB
 from snakefmt.exceptions import InvalidBlackConfiguration, MalformattedToml
+from snakefmt.snakefmt import main, read_snakefmt_defaults_from_pyproject_toml
+
+
+class TestConfigAdherence:
+    def test_config_adherence_for_python_outside_rules(self, cli_runner, tmp_path):
+        stdin = "include: 'a'\nlist_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        line_length = 30
+        config = tmp_path / "pyproject.toml"
+        config.write_text(f"[tool.snakefmt]\nline_length = {line_length}\n")
+        params = ["--config", str(config), "-"]
+
+        actual = cli_runner.invoke(main, params, input=stdin)
+        assert actual.exit_code == 0
+
+        expected_output = """include: \"a\"
+
+list_of_lots_of_things = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+]
+"""
+        assert actual.output == expected_output
+
+    def test_config_adherence_for_code_inside_rules(self, cli_runner, tmp_path):
+        stdin = (
+            f"rule a:\n"
+            f"{TAB}input:\n"
+            f"{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        )
+        line_length = 30
+        config = tmp_path / "pyproject.toml"
+        config.write_text(f"[tool.snakefmt]\nline_length = {line_length}\n")
+        params = ["--config", str(config), "-"]
+
+        actual = cli_runner.invoke(main, params, input=stdin)
+
+        assert actual.exit_code == 0
+
+        expected_output = (
+            "rule a:\n"
+            f"{TAB*1}input:\n"
+            f"{TAB*2}list_of_lots_of_things=[\n"
+            f"{TAB*3}1,\n{TAB*3}2,\n{TAB*3}3,\n{TAB*3}4,\n{TAB*3}5,\n"
+            f"{TAB*3}6,\n{TAB*3}7,\n{TAB*3}8,\n{TAB*3}9,\n{TAB*3}10,\n"
+            f"{TAB*2}],\n"
+        )
+
+        assert actual.output == expected_output
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -155,6 +155,25 @@ class TestPythonFormatting:
         )
         assert formatter.get_formatted() == expected
 
+    def test_pythoncode_line_formatting_before_snakecode(self):
+        formatter = setup_formatter(
+            'if c["a"] == 2:\n'
+            f'{TAB * 1}include: "a"\n'
+            'elif c["b"] is "b":\n'
+            f'{TAB * 1}include: "b"\n'
+            'elif c["c"]=="c":\n'
+            f'{TAB * 1}include: "c"\n'
+        )
+        expected = (
+            'if c["a"] == 2:\n'
+            f'{TAB * 1}include: "a"\n'
+            'elif c["b"] is "b":\n'
+            f'{TAB * 1}include: "b"\n'
+            'elif c["c"] == "c":\n'  # adds spaces here
+            f'{TAB * 1}include: "c"\n'
+        )
+        assert formatter.get_formatted() == expected
+
     def test_multiple_rules_inside_python_code(self):
         formatter = setup_formatter(
             "if condition:\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -437,6 +437,16 @@ class TestCommentTreatment:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
+    def test_comments_after_parameters_kept(self):
+        snakecode = (
+            f"rule a:\n"
+            f"{TAB * 1}input:\n"
+            f'{TAB * 2}"myparam", # a comment\n'
+            f'{TAB * 2}b="param2", # another comment\n'
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
+
 
 class TestNewlineSpacing:
     def test_non_rule_has_no_keyword_spacing_above(self):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -204,7 +204,6 @@ class TestPythonFormatting:
 
         assert actual == expected
 
-    @pytest.mark.xfail(reason="Indenting out by one for elements in list")
     def test_line_wrapped_python_code_inside_rule(self):
         content = (
             f"rule a:\n"
@@ -255,6 +254,7 @@ class TestSimpleParamFormatting:
         )
         assert formatter.get_formatted() == expected
 
+    @pytest.mark.xfail(reason="Don't know how to treat newlines in triple quoted yet")
     def test_triple_quoted_string_not_over_indented(self):
         snakecode = (
             "rule a:\n"
@@ -397,7 +397,7 @@ class TestCommaParamFormatting:
             f'{TAB * 2}"foo.txt",\n'
             f"{TAB * 1}params:\n"
             f"{TAB * 2}"
-            'obs=lambda w, input: ["{}={}".format(s, f) for s, f in zip(get_group_aliases(w), input.obs)],\n'  # noqa: E501  due to readability of test
+            'obs=lambda w, input: ["{}={}".format(s, f) for s, f in zip(get(w), input.obs)],\n'  # noqa: E501  due to readability of test
             f"{TAB * 2}p2=2,\n"
         )
         formatter = setup_formatter(snakefile)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -259,8 +259,7 @@ class TestSimpleParamFormatting:
         )
         assert formatter.get_formatted() == expected
 
-    @pytest.mark.xfail(reason="Don't know how to treat newlines in triple quoted yet")
-    def test_triple_quoted_string_not_over_indented(self):
+    def test_triple_quoted_shell_string_not_over_indented(self):
         snakecode = (
             "rule a:\n"
             f"{TAB * 1}shell:\n"
@@ -274,6 +273,26 @@ class TestSimpleParamFormatting:
         )
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
+
+    def test_param_with_string_mixture(self):
+        snakecode = (
+            "rule a:\n"
+            f"{TAB * 1}message:\n"
+            f'{TAB * 2}"Hello"\n'
+            f"{TAB * 2}'''    a string'''\n"
+            f'{TAB * 3}"World"\n'
+            f'{TAB * 3}"""		Yes"""\n'
+        )
+        expected = (
+            "rule a:\n"
+            f"{TAB * 1}message:\n"
+            f'{TAB * 2}"Hello"\n'
+            f'{TAB * 2}"""    a string"""\n'  # Quotes normalised
+            f'{TAB * 2}"World"\n'
+            f'{TAB * 2}"""		Yes"""\n'
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == expected
 
     def test_singleParamKeywordInRule_NewlineIndented(self):
         formatter = setup_formatter(

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -4,7 +4,9 @@ Completeness tests: checks that the grammar used is a bijection of the snakemake
 """
 from snakemake import parser
 
+from tests import setup_formatter
 from snakefmt.parser import grammar
+from snakefmt.parser.syntax import possibly_duplicated_keywords
 
 
 class TestCompleteness:
@@ -34,3 +36,13 @@ class TestCompleteness:
         target_keywords = set(parser.Rule.subautomata)
         existing_keywords = set(grammar.SnakeRule.spec)
         self.check_completeness(target_keywords, existing_keywords)
+
+
+class TestAllowedDuplicates:
+    def test_allowed_duplicates_in_snakefile(self):
+        for keyword in possibly_duplicated_keywords:
+            snakefile = ""
+            for i in range(2):
+                snakefile += f"{keyword}: val{i}\n"
+            formatter = setup_formatter(snakefile)
+            formatter.get_formatted()  # does not raise error

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -105,7 +105,6 @@ list_of_lots_of_things = [
 
         assert actual.output == expected_output
 
-    @pytest.mark.xfail(reason="Indenting out by one for elements in list")
     def test_config_adherence_for_code_inside_rules(self, cli_runner, tmp_path):
         stdin = (
             f"rule a:\n"


### PR DESCRIPTION
This PR closes #29 and #33 and refactors tests

## Added

* Bugfixes in formatting for the two issues mentioned above
* While processing both, I (of course...) hit some other formatting bugs/issues. I have added them as 3 failing tests. We can add them as issues. They are:
    * Triple quoted strings can get overindented for eg in `shell` context
    * Python code preceding nested snakecode does not get `black`ed
    * Python code following nested snakecode gets `black`ed but is an issue

The last two are totally related and should go in same issue. The first one doesn't really have to be an issue, not sure.
* Added `configfile` as possibly duplicated keyword (#27), and a grammar test testing duplicated keywords pass.

## Changed

* I refactored tests relating to configuration (pyproject.toml, user-specified toml, black toml settings, config adherence) to a source file `test_config`.py. I find this much more modular and readable.
* In the process of refactoring I found a bug due to use of `os.chdir(tmpdir)` when using `tmpdir` pytest fixture. Unrelated tests can then run from inside there and were trying to use created pyproject.toml. So I switched to using `testdir` fixture which uses `tmpdir` and starts the test in a tmpdir, but doesnt stay there. I added that plugin in `conftest.py`. 
* I subgrouped some tests under classes, for eg the CLI-related tests under `CLIDiff`, `CLICheck`, etc.. in `test_snakefmt`.
