### PR TITLE
Bugfixes, addressed issues and simplifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 homepage = "https://github.com/snakemake/snakefmt"
 repository = "https://github.com/snakemake/snakefmt"
 #documentation = ""  # todo
-keywords = ["snakemake", "formatter", "code", "codeformatter", "workflow-management"]
+keywords = ["python", "snakemake", "code", "formatter", "parser", "workflow", "management", "systems", "black"]
 
 [tool.poetry.scripts]
 snakefmt = 'snakefmt.snakefmt:main'

--- a/snakefmt/diff.py
+++ b/snakefmt/diff.py
@@ -1,22 +1,12 @@
-from typing import List, Union
+from typing import List
 from enum import Enum
 import difflib
 
 
-class CheckExitCode(Enum):
+class ExitCode(Enum):
     NO_CHANGE = 0
     WOULD_CHANGE = 1
     ERROR = 123
-
-    def __eq__(self, other: Union[int, "CheckExitCode"]) -> bool:
-        if self.__class__ is other.__class__:
-            return self.name == other.name and self.value == other.value
-        elif isinstance(other, int):
-            return self.value == other
-        else:
-            raise NotImplementedError(
-                f"Equality between CheckExitCode and {type(other)} is not implemented."
-            )
 
 
 class Diff:

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -116,9 +116,8 @@ class Formatter(Parser):
             raise InvalidPython(
                 f"Got error:\n```\n{str(e)}\n```\n" f"while formatting code with black."
             ) from None
-        used_indent = TAB * target_indent
-        indented = textwrap.indent(fmted, used_indent)
-        return indented
+        fmted = self.format_string(fmted, target_indent)
+        return fmted
 
     def format_string(self, string: str, target_indent: int) -> str:
         # Only indent non-triple-quoted string portions
@@ -128,7 +127,7 @@ class Formatter(Parser):
         for match in re.finditer(triple_quote_matcher, string):
             indented += textwrap.indent(string[pos : match.start()], used_indent)
             match_slice = string[match.start() : match.end()].replace("\t", TAB)
-            if match_slice.count("\n") > 0:
+            if match_slice.count("\n") > 0 and target_indent > 0:
                 # Note, cannot use 'eval' function as it
                 # unescapes escaped special chars like '\n'
                 dedented = match_slice.replace('"""', "")

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -75,7 +75,7 @@ class Formatter(Parser):
     def get_formatted(self):
         return self.result
 
-    def flush_buffer(self, from_python: bool = False):
+    def flush_buffer(self, from_python: bool = False) -> None:
         if len(self.buffer) == 0 or self.buffer.isspace():
             self.from_comment = False
             self.result += self.buffer
@@ -102,8 +102,7 @@ class Formatter(Parser):
         cur_indent = self.context.cur_indent
         self.add_newlines(cur_indent)
         formatted = (
-            f"{TAB * cur_indent}{self.context.keyword_name}:{self.context.comment}"
-            + "\n"
+            f"{TAB * cur_indent}{self.context.keyword_name}:{self.context.comment}\n"
         )
         self.result += formatted
 
@@ -209,6 +208,3 @@ class Formatter(Parser):
                 self.result += "\n\n"
         if self.first:
             self.first = False
-
-    def rule_like(self, kwrd):
-        return kwrd != "" and kwrd.split()[0] in rule_like_formatted

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -38,10 +38,10 @@ class Formatter(Parser):
         line_length: int = DEFAULT_LINE_LENGTH,
         black_config: Optional[PathLike] = None,
     ):
-        self._line_length = line_length
-        self.result = ""
-        self.lagging_comments = ""
-        self.first = True
+        self._line_length: int = line_length
+        self.result: str = ""
+        self.lagging_comments: str = ""
+        self.first: bool = True  # Whether formatting has occurred
 
         if black_config is None:
             self.black_mode = black.FileMode(line_length=self.line_length)
@@ -72,7 +72,7 @@ class Formatter(Parser):
     def line_length(self) -> int:
         return self._line_length
 
-    def get_formatted(self):
+    def get_formatted(self) -> str:
         return self.result
 
     def flush_buffer(
@@ -214,6 +214,11 @@ class Formatter(Parser):
         final_flush: bool = False,
         in_global_context: bool = False,
     ):
+        """
+        Top-level (indent of 0) rules and python code get two newlines separation
+        Indented rules/pycode get one newline separation
+        Comments immediately preceding rules/pycode get newlined with them
+        """
         comment_matches = 0
         comment_break = 1
         all_lines = formatted_string.splitlines()

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -119,7 +119,14 @@ class Formatter(Parser):
         for match in re.finditer(triple_quote_matcher, fmted):
             indented += textwrap.indent(fmted[pos : match.start()], used_indent)
             match_slice = fmted[match.start() : match.end()].replace("\t", TAB)
-            indented += f"{used_indent}{match_slice}"
+            if match_slice.count("\n") > 0:
+                # Note, cannot use 'eval' function as it
+                # unescapes escaped special chars like '\n'
+                dedented = match_slice.replace('"""', "")
+                dedented = f'"""{textwrap.dedent(dedented)}"""'
+                indented += textwrap.indent(dedented, used_indent)
+            else:
+                indented += f"{used_indent}{match_slice}"
             pos = match.end()
         indented += textwrap.indent(fmted[pos:], used_indent)
 

--- a/snakefmt/parser/parser.py
+++ b/snakefmt/parser/parser.py
@@ -9,7 +9,6 @@ from snakefmt.parser.syntax import (
     Syntax,
     KeywordSyntax,
     ParameterSyntax,
-    possibly_duplicated_keywords,
 )
 
 
@@ -138,8 +137,9 @@ class Parser(ABC):
                 keyword, self.context.cur_indent + 1, self.vocab, self.snakefile
             )
             self.process_keyword_param(param_context)
-            if keyword not in possibly_duplicated_keywords and not from_python:
-                self.context.add_processed_keyword(status.token, status.token.string)
+            self.context.add_processed_keyword(
+                status.token, status.token.string, check_dup=False
+            )
             return Syntax.Status(
                 param_context.token,
                 param_context.cur_indent,

--- a/snakefmt/parser/parser.py
+++ b/snakefmt/parser/parser.py
@@ -81,7 +81,7 @@ class Parser(ABC):
                     status = self.context.get_next_queriable(self.snakefile)
                     self.buffer += status.buffer
             self.context.cur_indent = status.indent
-        self.flush_buffer(from_python)
+        self.flush_buffer(from_python, final_flush=True)
 
     @property
     def vocab(self) -> Vocabulary:
@@ -96,7 +96,9 @@ class Parser(ABC):
         return self.context.target_indent
 
     @abstractmethod
-    def flush_buffer(self, from_python: bool = False) -> None:
+    def flush_buffer(
+        self, from_python: bool = False, final_flush: bool = False
+    ) -> None:
         pass
 
     @abstractmethod

--- a/snakefmt/parser/parser.py
+++ b/snakefmt/parser/parser.py
@@ -30,15 +30,6 @@ class Snakefile:
     def __next__(self):
         return next(self.tokens)
 
-    def __iter__(self):
-        return self
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.stream.close()
-
 
 class Parser(ABC):
     def __init__(self, snakefile: TokenIterator):

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -310,7 +310,7 @@ class ParameterSyntax(Syntax):
             if cur_param.has_value():
                 cur_param.add_elem(self.token)
         elif token_type == tokenize.COMMENT:
-            if str(cur_param) == "":
+            if str(cur_param) == "" and self.latest_pushed_param is not None:
                 target = self.latest_pushed_param.comments
             else:
                 target = cur_param.comments

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -358,14 +358,8 @@ class ParameterSyntax(Syntax):
 
 
 class SingleParam(ParameterSyntax):
-    def __init__(
-        self,
-        keyword_name: str,
-        target_indent: int,
-        incident_vocab: Vocabulary,
-        snakefile: TokenIterator = None,
-    ):
-        super().__init__(keyword_name, target_indent, incident_vocab, snakefile)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if self.num_params() > 1:
             raise TooManyParameters(
@@ -387,25 +381,13 @@ ParamList = ParameterSyntax
 
 
 class RuleInlineSingleParam(SingleParam):
-    def __init__(
-        self,
-        keyword_name: str,
-        target_indent: int,
-        incident_vocab: Vocabulary,
-        snakefile: TokenIterator = None,
-    ):
-        super().__init__(keyword_name, target_indent, incident_vocab, snakefile)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class NoKeywordParamList(ParameterSyntax):
-    def __init__(
-        self,
-        keyword_name: str,
-        target_indent: int,
-        incident_vocab: Vocabulary,
-        snakefile: TokenIterator = None,
-    ):
-        super().__init__(keyword_name, target_indent, incident_vocab, snakefile)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if len(self.keyword_params) > 0:
             raise InvalidParameterSyntax(

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -13,7 +13,6 @@ from snakefmt.exceptions import (
 )
 
 possibly_named_keywords = {"rule", "checkpoint", "subworkflow"}
-possibly_duplicated_keywords = {"include", "ruleorder", "localrules", "configfile"}
 
 """
 Token parsing
@@ -176,8 +175,8 @@ class KeywordSyntax(Syntax):
             if not from_python:
                 incident_context.add_processed_keyword(self.token, self.keyword_name)
 
-    def add_processed_keyword(self, token: Token, keyword: str):
-        if keyword in self.processed_keywords:
+    def add_processed_keyword(self, token: Token, keyword: str, check_dup: bool = True):
+        if check_dup and keyword in self.processed_keywords:
             raise DuplicateKeyWordError(
                 f"L{token.start[0]}: '{keyword}' specified twice."
             )
@@ -250,7 +249,6 @@ class ParameterSyntax(Syntax):
         snakefile: TokenIterator,
     ):
         super().__init__(keyword_name, target_indent, snakefile)
-        self.processed_keywords = set()
         self.positional_params, self.keyword_params = list(), list()
         self.eof = False
         self.incident_vocab = incident_vocab

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -308,7 +308,7 @@ class ParameterSyntax(Syntax):
             self.found_newline = True
             if cur_param.has_value():
                 cur_param.add_elem(self.token)
-        elif token_type == tokenize.COMMENT:
+        elif token_type == tokenize.COMMENT and not self.in_brackets:
             if str(cur_param) == "" and self.latest_pushed_param is not None:
                 target = self.latest_pushed_param.comments
             else:

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -20,7 +20,7 @@ Token parsing
 QUOTES = {'"', "'"}
 BRACKETS_OPEN = {"(", "[", "{"}
 BRACKETS_CLOSE = {")", "]", "}"}
-TAB = "    "
+TAB = "    "  # PEP8, 4 spaces
 
 
 def is_colon(token: Token):
@@ -61,10 +61,11 @@ spacing_triggers = {
 def operator_skip_spacing(prev_token: Token, token: Token) -> bool:
     if prev_token.type != tokenize.OP and token.type != tokenize.OP:
         return False
-    elif (
+    if (
         prev_token.string in BRACKETS_OPEN
+        or prev_token.string == "."
         or token.string in BRACKETS_CLOSE
-        or token.string in {"[", ":"}
+        or token.string in {"[", ":", "."}
     ):
         return True
     else:

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -68,6 +68,8 @@ def operator_skip_spacing(prev_token: Token, token: Token) -> bool:
         or token.string in {"[", ":", "."}
     ):
         return True
+    elif prev_token.type == tokenize.NAME and token.string == "(":
+        return True
     else:
         return False
 
@@ -217,7 +219,8 @@ class KeywordSyntax(Syntax):
                 prev_token = None
                 continue
 
-            if newline:  # Records relative tabbing, used for python code formatting
+            # Records relative tabbing, used for python code formatting
+            if newline and not token.type == tokenize.COMMENT:
                 buffer += TAB * self.effective_indent
 
             if token.type == tokenize.NAME and self.queriable:

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -11,7 +11,7 @@ from black import get_gitignore
 from pathspec import PathSpec
 
 from snakefmt import __version__, DEFAULT_LINE_LENGTH
-from snakefmt.diff import Diff, CheckExitCode
+from snakefmt.diff import Diff, ExitCode
 from snakefmt.formatter import Formatter
 from snakefmt.parser.parser import Snakefile
 
@@ -143,9 +143,9 @@ def get_snakefiles_in_dir(
     is_flag=True,
     help=(
         f"Don't write the files back, just return the status. Return code "
-        f"{CheckExitCode.NO_CHANGE.value} means nothing would change. Return code "
-        f"{CheckExitCode.WOULD_CHANGE.value} means some files would be reformatted. "
-        f"Return code {CheckExitCode.ERROR.value} means there was an error."
+        f"{ExitCode.NO_CHANGE.value} means nothing would change. Return code "
+        f"{ExitCode.WOULD_CHANGE.value} means some files would be reformatted. "
+        f"Return code {ExitCode.ERROR.value} means there was an error."
     ),
 )
 @click.option(
@@ -337,11 +337,11 @@ def main(
             logging.info(
                 f"All {len(files_to_format)} file(s) would be left unchanged 🎉"
             )
-            ctx.exit(CheckExitCode.NO_CHANGE.value)
+            ctx.exit(ExitCode.NO_CHANGE.value)
         elif files_with_errors > 0:
-            exit_value = CheckExitCode.ERROR.value
+            exit_value = ExitCode.ERROR.value
         elif files_changed > 0:
-            exit_value = CheckExitCode.WOULD_CHANGE.value
+            exit_value = ExitCode.WOULD_CHANGE.value
 
         if files_with_errors > 0:
             logging.info(f"{files_with_errors} file(s) raised parsing errors 🤕")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ class TestConfigAdherence:
 
         expected_output = """include: \"a\"
 
+
 list_of_lots_of_things = [
     1,
     2,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,61 +1,16 @@
-import pytest
-
-from snakefmt.diff import Diff, CheckExitCode
-
-
-class TestCheckExitCode:
-    def test_equality_two_enums(self):
-        actual = CheckExitCode.WOULD_CHANGE
-        other = CheckExitCode.WOULD_CHANGE
-
-        assert actual == other
-
-    def test_equality_two_different_enums(self):
-        actual = CheckExitCode.WOULD_CHANGE
-        other = CheckExitCode.ERROR
-
-        assert actual != other
-
-    def test_equality_one_enum_one_int_same_value(self):
-        actual = CheckExitCode.NO_CHANGE
-        other = 0
-
-        assert actual == other
-
-    def test_equality_one_enum_one_int_different_value(self):
-        actual = CheckExitCode.ERROR
-        other = 0
-
-        assert actual != other
-
-    def test_equality_one_enum_one_float_raises_error(self):
-        actual = CheckExitCode.ERROR
-        other = 123.0
-
-        with pytest.raises(NotImplementedError):
-            actual == other
+from snakefmt.diff import Diff
 
 
 class TestCompare:
     def test_empty_strings_returns_empty(self):
-        original = ""
-        new = ""
         diff = Diff()
-
-        actual = diff.compare(original, new)
-        expected = ""
-
-        assert actual == expected
+        assert diff.compare("", "") == ""
 
     def test_same_strings_returns_empty(self):
         original = "foo\n    bar"
-        new = "foo\n    bar"
         diff = Diff()
 
-        actual = diff.compare(original, new)
-        expected = ""
-
-        assert actual == expected
+        assert diff.compare(original, original) == ""
 
     def test_strings_differ_by_one_char_compact(self):
         original = "foo\n    bar"
@@ -121,7 +76,7 @@ class TestIsChanged:
         new = "foo\n    bar\n\n"
         diff = Diff(compact=True)
 
-        assert not diff.is_changed(original, new)
+        assert diff.is_changed(original, new) is False
 
     def test_same_strings_non_compact_returns_false(self):
         original = "foo\n    bar"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -175,11 +175,11 @@ class TestComplexPythonFormatting:
 
     def test_pythoncode_parser_based_formatting_before_snakecode(self):
         snakecode = (
-            'if c["a"]is None:\n'
+            'if c["a"]is None:\n'  # space needed before '['
             f'{TAB * 1}include: "a"\n'
-            'elif c["b"] == "b":\n'
+            'elif myobj.attr == "b":\n'
             f'{TAB * 1}include: "b"\n'
-            'elif c["c"]=="c":\n'
+            'elif len(c["c"])==3:\n'  # spaces needed either side of '=='
             f'{TAB * 1}include: "c"\n'
         )
 
@@ -187,9 +187,9 @@ class TestComplexPythonFormatting:
         expected = (
             'if c["a"] is None:\n'
             f'{TAB * 1}include: "a"\n'
-            'elif c["b"] == "b":\n'
+            'elif myobj.attr == "b":\n'
             f'{TAB * 1}include: "b"\n'
-            'elif c["c"] == "c":\n'  # adds spaces here
+            'elif len(c["c"]) == 3:\n'
             f'{TAB * 1}include: "c"\n'
         )
         assert formatter.get_formatted() == expected

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -290,11 +290,11 @@ class TestComplexPythonFormatting:
         with mock.patch(
             "snakefmt.formatter.Formatter.run_black_format_str", spec=True
         ) as mock_m:
-            mock_m.return_value = ""
+            mock_m.return_value = "if condition:\n"
             setup_formatter(snakecode)
-            assert mock_m.call_count == 2
-            assert mock_m.call_args_list[0] == mock.call('"a"')
-            assert mock_m.call_args_list[1] == mock.call("b = 2\n")
+            assert mock_m.call_count == 3
+            assert mock_m.call_args_list[1] == mock.call('"a"')
+            assert mock_m.call_args_list[2] == mock.call("b = 2\n")
 
         formatter = setup_formatter(snakecode)
         expected = (
@@ -304,19 +304,17 @@ class TestComplexPythonFormatting:
         )
         assert formatter.get_formatted() == expected
 
-    @pytest.mark.xfail(
-        reason="python code prior to nested snakecode needs is not yet processed"
-    )
     def test_python_code_before_nested_snakecode_gets_formatted(self):
         snakecode = "b=2\n" "if condition:\n" f'{TAB * 1}include: "a"\n'
         with mock.patch(
             "snakefmt.formatter.Formatter.run_black_format_str", spec=True
         ) as mock_m:
+            mock_m.return_value = "b=2\nif condition:\n"
             formatter = setup_formatter(snakecode)
             assert mock_m.call_count == 2
 
         formatter = setup_formatter(snakecode)
-        expected = "b = 2\n" "if condition:\n" f'{TAB * 1}include: "a"\n'
+        expected = "b = 2\n" "if condition:\n\n" f'{TAB * 1}include: "a"\n'
         assert formatter.get_formatted() == expected
 
     def test_pythoncode_parser_based_formatting_before_snakecode(self):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -641,7 +641,7 @@ below_rule = "2spaces"
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
-    def test_rule_tagged_comment_stays_rule_tagged(self):
+    def test_comment_sticks_to_rule(self):
         snakecode = (
             "def p():\n"
             f"{TAB * 1}pass\n"
@@ -671,6 +671,16 @@ below_rule = "2spaces"
             f'include: "a"\n'
         )
         assert formatter.get_formatted() == expected
+
+    def test_buffer_with_lone_comment(self):
+        snakecode = f'include: "a"\n# A comment\ninclude: "b"\n'
+        expected = f'include: "a"\n\n\n# A comment\ninclude: "b"\n'
+        assert setup_formatter(snakecode).get_formatted() == expected
+
+    def test_comment_inside_python_code_sticks_to_rule(self):
+        snakecode = f"if p:\n" f"{TAB * 1}# A comment\n" f'{TAB * 1}include: "a"\n'
+        expected = f"if p:\n\n" f"{TAB * 1}# A comment\n" f'{TAB * 1}include: "a"\n'
+        assert setup_formatter(snakecode).get_formatted() == expected
 
     def test_comment_below_keyword_gets_spaced(self):
         formatter = setup_formatter(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -313,6 +313,40 @@ rule a:
 '''
         assert formatter.get_formatted() == expected
 
+    def test_docstrings_get_reindented(self):
+        snakecode = f'''def f():
+  """Does not do
+  much
+    """
+  pass
+
+
+rule a:
+  """
+{' ' * 2}The rule
+{' ' * 8}a
+"""
+  message:
+    "a"
+'''
+        formatter = setup_formatter(snakecode)
+        expected = f'''def f():
+{TAB * 1}"""Does not do
+  much
+{TAB * 1}"""
+{TAB * 1}pass
+
+
+rule a:
+{TAB * 1}"""
+{TAB * 1}The rule
+{TAB * 1}{' ' * 6}a
+{TAB * 1}"""
+{TAB * 1}message:
+{TAB * 2}"a"
+'''
+        assert formatter.get_formatted() == expected
+
 
 class TestSimpleParamFormatting:
     def test_simple_rule_one_input(self):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -258,10 +258,12 @@ class TestSimplePythonFormatting:
 class TestComplexPythonFormatting:
     """
     Snakemake syntax can be nested inside python code
+
+    As for black non-top level functions, 1 line spacing is used between
+    code and keywords, and two between keyword and code.
     """
 
     def test_snakemake_code_inside_python_code(self):
-        # The rules inside python code get formatted
         formatter = setup_formatter(
             "if condition:\n"
             f"{TAB * 1}rule a:\n"
@@ -271,12 +273,12 @@ class TestComplexPythonFormatting:
             f'{TAB * 2}script: "c.py"'
         )
         expected = (
-            "if condition:\n"
+            "if condition:\n\n"
             f"{TAB * 1}rule a:\n"
             f"{TAB * 2}input:\n"
             f'{TAB * 3}"a",\n'
-            f'{TAB * 3}"b",\n'
-            "else:\n"
+            f'{TAB * 3}"b",\n\n\n'
+            "else:\n\n"
             f"{TAB * 1}rule b:\n"
             f"{TAB * 2}script:\n"
             f'{TAB * 3}"c.py"\n'
@@ -296,7 +298,7 @@ class TestComplexPythonFormatting:
 
         formatter = setup_formatter(snakecode)
         expected = (
-            "if condition:\n"
+            "if condition:\n\n"
             f'{TAB * 1}include: "a"\n'
             "\n\nb = 2\n"  # python code gets formatted here
         )
@@ -319,21 +321,21 @@ class TestComplexPythonFormatting:
 
     def test_pythoncode_parser_based_formatting_before_snakecode(self):
         snakecode = (
-            'if c["a"]is None:\n'  # space needed before '['
-            f'{TAB * 1}include: "a"\n'
-            'elif myobj.attr == "b":\n'
-            f'{TAB * 1}include: "b"\n'
-            'elif len(c["c"])==3:\n'  # spaces needed either side of '=='
+            'if c["a"]is None:\n\n'  # space needed before '['
+            f'{TAB * 1}include: "a"\n\n\n'
+            'elif myobj.attr == "b":\n\n'
+            f'{TAB * 1}include: "b"\n\n\n'
+            'elif len(c["c"])==3:\n\n'  # spaces needed either side of '=='
             f'{TAB * 1}include: "c"\n'
         )
 
         formatter = setup_formatter(snakecode)
         expected = (
-            'if c["a"] is None:\n'
-            f'{TAB * 1}include: "a"\n'
-            'elif myobj.attr == "b":\n'
-            f'{TAB * 1}include: "b"\n'
-            'elif len(c["c"]) == 3:\n'
+            'if c["a"] is None:\n\n'
+            f'{TAB * 1}include: "a"\n\n\n'
+            'elif myobj.attr == "b":\n\n'
+            f'{TAB * 1}include: "b"\n\n\n'
+            'elif len(c["c"]) == 3:\n\n'
             f'{TAB * 1}include: "c"\n'
         )
         assert formatter.get_formatted() == expected
@@ -358,10 +360,10 @@ class TestComplexPythonFormatting:
             f'{TAB * 2}script: "b"'
         )
         expected = (
-            "if condition:\n"
+            "if condition:\n\n"
             f"{TAB * 1}rule a:\n"
             f"{TAB * 2}wrapper:\n"
-            f'{TAB * 3}"a"\n'
+            f'{TAB * 3}"a"\n\n'
             f"{TAB * 1}rule b:\n"
             f"{TAB * 2}script:\n"
             f'{TAB * 3}"b"\n'
@@ -370,9 +372,9 @@ class TestComplexPythonFormatting:
 
     def test_parameter_keywords_inside_python_code(self):
         snakecode = (
-            "if condition:\n"
-            f'{TAB * 1}include: "a"\n'
-            f"else:\n"
+            "if condition:\n\n"
+            f'{TAB * 1}include: "a"\n\n\n'
+            f"else:\n\n"
             f'{TAB * 1}include: "b"\n'
             f'\n\ninclude: "c"\n'
         )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -631,13 +631,44 @@ below_rule = "2spaces"
 
         assert formatter.get_formatted() == expected
 
-    def test_comment_above_does_not_trigger_spacing(self):
+    def test_initial_comment_does_not_trigger_spacing(self):
         snakecode = (
             f"# load config\n" f"rule all:\n" f"{TAB * 1}input:\n" f"{TAB * 2}files,\n"
         )
 
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
+
+    def test_rule_tagged_comment_stays_rule_tagged(self):
+        snakecode = (
+            "def p():\n"
+            f"{TAB * 1}pass\n"
+            f"#My rule a\n"
+            f"rule a:\n"
+            f"{TAB * 1}threads: 1\n"
+        )
+        formatter = setup_formatter(snakecode)
+        expected = (
+            "def p():\n"
+            f"{TAB * 1}pass\n\n\n"
+            f"# My rule a\n"
+            f"rule a:\n"
+            f"{TAB * 1}threads: 1\n"
+        )
+        assert formatter.get_formatted() == expected
+
+    def test_keyword_disjoint_comment_stays_keyword_disjoint(self):
+        snakecode = (
+            "def p():\n" f"{TAB * 1}pass\n" f"#A lone comment\n\n" f'include: "a"\n'
+        )
+        formatter = setup_formatter(snakecode)
+        expected = (
+            "def p():\n"
+            f"{TAB * 1}pass\n\n\n"  # Newlined by black
+            f"# A lone comment\n\n\n"  # Remains lone comment
+            f'include: "a"\n'
+        )
+        assert formatter.get_formatted() == expected
 
     def test_comment_below_keyword_gets_spaced(self):
         formatter = setup_formatter(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -22,7 +22,9 @@ def test_emptyInput_emptyOutput():
 
 
 class TestSimplePythonFormatting:
-    @mock.patch("snakefmt.formatter.Formatter.run_black_format_str", spec=True)
+    @mock.patch(
+        "snakefmt.formatter.Formatter.run_black_format_str", spec=True, return_value=""
+    )
     def test_commented_snakemake_syntax_formatted_as_python_code(self, mock_method):
         """
         Tests this line triggers call to black formatting
@@ -36,7 +38,9 @@ class TestSimplePythonFormatting:
         python_code = "if p:\n" f"{TAB * 1}for elem in p:\n" f"{TAB * 2}dothing(elem)\n"
         # test black gets called
         with mock.patch(
-            "snakefmt.formatter.Formatter.run_black_format_str", spec=True
+            "snakefmt.formatter.Formatter.run_black_format_str",
+            spec=True,
+            return_value="",
         ) as mock_m:
             formatter = setup_formatter(python_code)
             mock_m.assert_called_once()
@@ -60,8 +64,8 @@ class TestSimplePythonFormatting:
             "rule a:\n"
             f"{TAB * 1}run:\n"
             f"{TAB * 2}def s(a):\n"
-            f"{TAB * 2}    if a:\n"
-            f'{TAB * 3}    return "Hello World"\n'
+            f"{TAB * 3}if a:\n"
+            f'{TAB * 4}return "Hello World"\n'
         )
         formatter = setup_formatter(snake_code)
         assert formatter.get_formatted() == snake_code
@@ -140,6 +144,7 @@ class TestComplexPythonFormatting:
         with mock.patch(
             "snakefmt.formatter.Formatter.run_black_format_str", spec=True
         ) as mock_m:
+            mock_m.return_value = ""
             formatter = setup_formatter(snakecode)
             assert mock_m.call_count == 2
             assert mock_m.call_args_list[0] == mock.call('"a"', 0)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -338,7 +338,7 @@ class TestComplexPythonFormatting:
         )
         assert formatter.get_formatted() == expected
 
-    @pytest.mark.xfail(reason="black cannot format lone 'else'")
+    @pytest.mark.xfail(reason="'else:' block not recognised as being from_python")
     def test_nested_snakecode_python_else_does_not_fail(self):
         snakecode = (
             'if c["a"] is None:\n'

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -4,9 +4,7 @@ Completeness tests: checks that the grammar used is a bijection of the snakemake
 """
 from snakemake import parser
 
-from tests import setup_formatter
 from snakefmt.parser import grammar
-from snakefmt.parser.syntax import possibly_duplicated_keywords
 
 
 class TestCompleteness:
@@ -36,13 +34,3 @@ class TestCompleteness:
         target_keywords = set(parser.Rule.subautomata)
         existing_keywords = set(grammar.SnakeRule.spec)
         self.check_completeness(target_keywords, existing_keywords)
-
-
-class TestAllowedDuplicates:
-    def test_allowed_duplicates_in_snakefile(self):
-        for keyword in possibly_duplicated_keywords:
-            snakefile = ""
-            for i in range(2):
-                snakefile += f"{keyword}: val{i}\n"
-            formatter = setup_formatter(snakefile)
-            formatter.get_formatted()  # does not raise error

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -176,6 +176,13 @@ class TestPythonCode:
         with pytest.raises(InvalidPython):
             setup_formatter(python_code)
 
+    def test_invalid_python_code_preceding_nested_rule_fails(self):
+        snakecode = (
+            f"if invalid code here:\n" f"{TAB * 1}rule a:\n" f"{TAB * 2}threads: 1"
+        )
+        with pytest.raises(InvalidPython):
+            setup_formatter(snakecode)
+
     def test_rules_inside_python_code_passes(self):
         snake = (
             f"if condition1:\n"
@@ -190,7 +197,7 @@ class TestPythonCode:
             f"if condition1:\n"
             f"{TAB * 1}rule all:\n"
             f'{TAB * 2}wrapper:"a"\n'
-            f"else if condition2:\n"
+            f"elif condition2:\n"
             f"{TAB * 1}rule all:\n"
             f'{TAB * 2}wrapper:"b"\n'
             f"else:\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -62,12 +62,6 @@ class TestKeywordSyntax:
             snakefile = Snakefile(stream)
             Formatter(snakefile)
 
-    def test_duplicate_parameter_fails_SMK_NOBREAK(self):
-        with pytest.raises(DuplicateKeyWordError, match="threads"):
-            stream = StringIO("rule a:" "\n\tthreads: 3" "\n\tthreads: 5")
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
-
     def test_duplicate_rule_fails_SMK_NOBREAK(self):
         with pytest.raises(DuplicateKeyWordError, match="rule a"):
             stream = StringIO("rule a:\n" '\tinput: "a"\n' "rule a:\n" '\tinput:"b"')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -180,8 +180,11 @@ class TestPythonCode:
         snakecode = (
             f"if invalid code here:\n" f"{TAB * 1}rule a:\n" f"{TAB * 2}threads: 1"
         )
+        snakecode2 = f"def p:\n" f"{TAB * 1}rule a:\n" f"{TAB * 2}threads: 1"
         with pytest.raises(InvalidPython):
             setup_formatter(snakecode)
+        with pytest.raises(InvalidPython):
+            setup_formatter(snakecode2)
 
     def test_rules_inside_python_code_passes(self):
         snake = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -117,7 +117,7 @@ class TestParamSyntax:
 
     def test_parameter_list_keyword_disallows_kwarg(self):
         with pytest.raises(InvalidParameterSyntax):
-            snake_code = f"envvars:\n" f'{TAB * 1}"VAR1"' f'{TAB * 1}var2 = "VAR2"'
+            snake_code = f"envvars:\n" f'{TAB * 1}"VAR1",' f'{TAB * 1}var2 = "VAR2"'
             setup_formatter(snake_code)
 
     def test_dictionary_unpacking_passes(self):

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from snakefmt.formatter import TAB
-from snakefmt.diff import CheckExitCode
+from snakefmt.diff import ExitCode
 from snakefmt.snakefmt import (
     construct_regex,
     main,
@@ -104,32 +104,29 @@ class TestCLIBasic:
 
 
 class TestCLICheck:
-    def test_check_file_needs_no_changes_exit_code_0(self, cli_runner):
+    def test_check_file_needs_no_changes_correct_exit_code(self, cli_runner):
         stdin = 'include: "a"\n'
         params = ["--check", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-        expected = CheckExitCode.NO_CHANGE
 
-        assert actual.exit_code == expected
+        assert ExitCode(actual.exit_code) is ExitCode.NO_CHANGE
 
-    def test_check_file_needs_changes_exit_code_1(self, cli_runner):
+    def test_check_file_needs_changes_correct_exit_code(self, cli_runner):
         stdin = 'include:  "a"\n'
         params = ["--check", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-        expected = CheckExitCode.WOULD_CHANGE
 
-        assert actual.exit_code == expected
+        assert ExitCode(actual.exit_code) is ExitCode.WOULD_CHANGE
 
-    def test_check_file_syntax_invalid_exit_code_123(self, cli_runner):
+    def test_check_file_syntax_correct_exit_code(self, cli_runner):
         stdin = "foo:  \n"
         params = ["--check", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-        expected = CheckExitCode.ERROR
 
-        assert actual.exit_code == expected
+        assert ExitCode(actual.exit_code) is ExitCode.ERROR
 
     def test_check_does_not_format_file(self, cli_runner, tmp_path):
         content = "include: 'a'\nlist_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8]"
@@ -139,8 +136,7 @@ class TestCLICheck:
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.WOULD_CHANGE
-        assert result.exit_code == expected_exit_code
+        assert ExitCode(result.exit_code) is ExitCode.WOULD_CHANGE
 
         expected_contents = content
         actual_contents = snakefile.read_text()
@@ -156,8 +152,7 @@ class TestCLICheck:
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.NO_CHANGE
-        assert result.exit_code == expected_exit_code
+        assert ExitCode(result.exit_code) is ExitCode.NO_CHANGE
 
     def test_check_two_files_one_will_change(self, cli_runner, tmp_path):
         content = 'include: "a"\n'
@@ -170,8 +165,7 @@ class TestCLICheck:
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.WOULD_CHANGE
-        assert result.exit_code == expected_exit_code
+        assert ExitCode(result.exit_code) is ExitCode.WOULD_CHANGE
 
     def test_check_two_files_one_has_errors(self, cli_runner, tmp_path):
         content = 'include: "a"\n'
@@ -184,8 +178,7 @@ class TestCLICheck:
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.ERROR
-        assert result.exit_code == expected_exit_code
+        assert ExitCode(result.exit_code) is ExitCode.ERROR
 
     def test_check_and_diff_only_runs_check(self, cli_runner, tmp_path):
         content = 'include: "a"\n'
@@ -198,8 +191,7 @@ class TestCLICheck:
 
         result = cli_runner.invoke(main, params)
 
-        expected_exit_code = CheckExitCode.WOULD_CHANGE.value
-        assert result.exit_code == expected_exit_code
+        assert ExitCode(result.exit_code) is ExitCode.WOULD_CHANGE
         assert result.output == ""
 
 
@@ -307,7 +299,7 @@ class TestConstructRegex:
 
         assert actual == expected
 
-    def test_invalidRegex_raisesError(self):
+    def test_invalid_regex_raises_error(self):
         regex = r"?"
 
         with pytest.raises(re.error):


### PR DESCRIPTION
# Added

* Removed `Enum` based comparisons and unit tests: simplifies our codebase at no cost
* Type annotations, function doscstrings and comments for future us/helping understanding
* Python code preceding a nested (=indented) snakemake keyword/context gets formatted with `black`. This meant solving a formatted line being a lone `else:` for example, which is invalid python syntax. Solves #40 , #41
* Triple quoted string indenting. Solves #39

# Modified

* Newline paradigm: two newlines between top level elements, one newline in nested context. This mirrors black. `rule` is basically treated like a python class/function in this respect. Solves #40
* Comments: they get tagged along elements, following what black does. If a comment occurs just before a `rule` (or an `include`, or any other top level keyword- or a class/function), it gets newlined with the rule.

