### PR TITLE
Improve test coverage and add cmdline info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ design and specifications of [Black][black].
 
 > **⚠️WARNING⚠️**: `snakefmt` modifies files in-place by default, thus we strongly
 > recommend ensuring your files are under version control before doing any formatting.
-> This is also to protect you from bugs as the project is still new. Alternatively, you
-> can pipe the file in from stdin, which will print it to the screen, or use the
-> `--diff` option. See [Usage](#usage) for more details.
+> This is also to protect you from bugs as the project is still new. You
+> can also pipe the file in from stdin, which will print it to the screen, or use the
+> `--diff` or `--check` options. See [Usage](#usage) for more details.
 
 [TOC]: #
 
@@ -156,6 +156,9 @@ Usage: snakefmt [OPTIONS] [SRC]...
   SRC specifies directories and files to format. Directories will be
   searched for file names that conform to the include/exclude patterns
   provided.
+
+  Files are modified in-place by default; use diff, check, or  `snakefmt - <
+  Snakefile` to avoid this.
 
 Options:
   -l, --line-length INT  Lines longer than INT will be wrapped.  [default: 88]

--- a/snakefmt/parser/grammar.py
+++ b/snakefmt/parser/grammar.py
@@ -13,7 +13,7 @@ from snakefmt.parser.syntax import (
 
 class Grammar(NamedTuple):
     """
-    Ties together a vocabulary and a syntax reader
+    Ties together a vocabulary and a context (=syntax reader)
     When a keyword from `vocab` is recognised, a new grammar is induced
     """
 

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -80,7 +80,6 @@ def get_snakefiles_in_dir(
     """Generate all files under `path` whose paths are not excluded by the
     `exclude` regex, but are included by the `include` regex.
     Symbolic links pointing outside of the `root` directory are ignored.
-    `report` is where output about exclusions goes.
     Adapted from
     https://github.com/psf/black/blob/ce14fa8b497bae2b50ec48b3bd7022573a59cdb1/black.py#L3519-L3573
     """
@@ -229,12 +228,18 @@ def main(
     """The uncompromising Snakemake code formatter.
 
     SRC specifies directories and files to format. Directories will be searched for
-    file names that conform to the include/exclude patterns provided."""
+    file names that conform to the include/exclude patterns provided.
+
+    Files are modified in-place by default; use diff, check, or
+     `snakefmt - < Snakefile` to avoid this.
+    """
     log_level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(format="[%(levelname)s] %(message)s", level=log_level)
 
     if not src:
-        click.echo("No path provided. Nothing to do 😴", err=True)
+        click.echo(
+            "No path provided. Nothing to do 😴. Call with -h for help.", err=True
+        )
         ctx.exit(0)
 
     if "-" in src and len(src) > 1:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -523,6 +523,11 @@ class TestCommentTreatment:
         expected = 'include: "a"\n\n\n# A comment\n'
         assert formatter.get_formatted() == expected
 
+    def test_comment_after_keyword_kept(self):
+        snakecode = "rule a: # A comment \n" f"{TAB * 1}threads: 4\n"
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
+
     def test_comments_after_parameters_kept(self):
         snakecode = (
             f"rule a:\n"

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -351,7 +351,6 @@ class TestCLIValidRegex:
             self.create_temp_filesystem_in(abs_tmpdir)
             snakefiles = get_snakefiles_in_dir(
                 path=Path(tmpdir),
-                root=abs_tmpdir,
                 include=include,
                 exclude=exclude,
                 gitignore=mock_gitignore,
@@ -373,7 +372,6 @@ class TestCLIValidRegex:
             self.create_temp_filesystem_in(abs_tmpdir)
             snakefiles = get_snakefiles_in_dir(
                 path=Path(tmpdir),
-                root=abs_tmpdir,
                 include=include,
                 exclude=exclude,
                 gitignore=mock_gitignore,
@@ -397,7 +395,6 @@ class TestCLIValidRegex:
             self.create_temp_filesystem_in(abs_tmpdir)
             snakefiles = get_snakefiles_in_dir(
                 path=Path(tmpdir),
-                root=abs_tmpdir,
                 include=include,
                 exclude=exclude,
                 gitignore=mock_gitignore,


### PR DESCRIPTION
## Modified

* Removed some unnecessary error checks in snakefmt/get_snakefiles_in_dir function. These were in place for checking a file relative to the root of a project (black code), but we don't do that. Improves coverage for free ;-)
* More  info at command line about modifying files in place and advertise `-h` for help

## Added 
* Add a test for comments after keywords