### PR TITLE
Use black config even if no snakefmt settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Fixed
+
+- `black` config was not being used if it did not contain `[tool.snakefmt]` [[#73][73]]
+- better handling of `black.FileMode` params [[#73][73]]
+
 ## [0.2.1]
 
 ### Added
@@ -85,5 +90,6 @@ is 40 character long, the line is 48 characters long. However, we were only pass
 [65]: https://github.com/snakemake/snakefmt/issues/65
 [67]: https://github.com/snakemake/snakefmt/issues/67
 [68]: https://github.com/snakemake/snakefmt/issues/68
+[73]: https://github.com/snakemake/snakefmt/issues/73
 [74]: https://github.com/snakemake/snakefmt/pull/74
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ jobs:
 Additional configuration parameters can be specified by creating `.github/linters/.snakefmt.toml`:
 ```toml
 [tool.black]
-skip-string-normalization = 1
+skip_string_normalization = true
 ```
 
 For more information check the `super-linter` readme.
@@ -313,12 +313,12 @@ configuration file.
 
 ```toml
 [tool.snakefmt]
-line-length = 90
+line_length = 90
 include = '\.smk$|^Snakefile|\.py$'
 
 # snakefmt passes these options on to black
 [tool.black]
-target-version = ["py37"]
+skip_string_normalization = true
 ```
 
 In this example we increase the `--line-length` value and also include python (`*.py`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ isort = "^5.1.0"
 
 [tool.black]
 line-length = 88
-target-version = ['py37']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -8,12 +8,7 @@ import black
 import toml
 
 from snakefmt import DEFAULT_LINE_LENGTH
-from snakefmt.exceptions import (
-    InvalidBlackConfiguration,
-    InvalidParameterSyntax,
-    InvalidPython,
-    MalformattedToml,
-)
+from snakefmt.exceptions import InvalidParameterSyntax, InvalidPython, MalformattedToml
 from snakefmt.parser.grammar import SnakeRule
 from snakefmt.parser.parser import Parser
 from snakefmt.parser.syntax import (
@@ -94,10 +89,7 @@ class Formatter(Parser):
 
             snakecase_config[key] = val
 
-        try:
-            return black.FileMode(**snakecase_config)
-        except TypeError as error:
-            raise InvalidBlackConfiguration(error)
+        return black.FileMode(**snakecase_config)
 
     @property
     def line_length(self) -> int:

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 import textwrap
 from ast import parse as ast_parse
@@ -23,12 +24,6 @@ from snakefmt.types import TokenIterator
 
 PathLike = Union[Path, str]
 rule_like_formatted = {"rule", "checkpoint"}
-valid_black_filemode_params = {
-    "target_versions",
-    "line_length",
-    "string_normalization",
-    "is_pyi",
-}
 
 triple_quote_matcher = re.compile(
     r"^\s*(\w?\"{3}.*?\"{3})|^\s*(\w?'{3}.*?'{3})", re.DOTALL | re.MULTILINE
@@ -74,6 +69,8 @@ class Formatter(Parser):
 
         if "line_length" not in config:
             config["line_length"] = self.line_length
+
+        valid_black_filemode_params = inspect.getfullargspec(black.FileMode).args
 
         snakecase_config = {}
         for key, val in config.items():

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -60,7 +60,7 @@ def read_snakefmt_defaults_from_pyproject_toml(
         )
 
     if not config:
-        return None
+        return value
 
     if ctx.default_map is None:
         ctx.default_map = {}

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -47,6 +47,8 @@ class TestCLIBasic:
 
         actual = cli_runner.invoke(main, params, input=stdin)
 
+        print(actual.exception)
+
         assert actual.exit_code == 0
 
         expected_output = f'rule all:\n{TAB}input:\n{TAB*2}"c",\n'
@@ -415,3 +417,26 @@ class TestCLIValidRegex:
         )
         expected = Counter(["rules/map.smk", "rules/test/test.smk"])
         assert actual == expected
+
+
+class TestCliConfig:
+    def test_black_skip_string_norm_is_obeyed(self, tmp_path, cli_runner):
+        path = tmp_path / "config.toml"
+        path.write_text("[tool.black]\nskip-string-normalization = 1")
+        stdin = "x = 'foo'\n\n\nconfigfile: 'a'\n"
+        params = ["--config", str(path), "--check", "-"]
+
+        result = cli_runner.invoke(main, params, input=stdin)
+        expected_exit_code = 0
+
+        assert result.exit_code == expected_exit_code
+
+    def test_black_string_norm_is_obeyed(self, tmp_path, cli_runner):
+        path = tmp_path / "config.toml"
+        path.write_text("[tool.black]\nskip-string-normalization = false")
+        stdin = "x = 'foo'\n\n\nconfigfile: 'a'\n"
+        params = ["--config", str(path), "--check", "-"]
+
+        result = cli_runner.invoke(main, params, input=stdin)
+
+        assert result.exit_code != 0


### PR DESCRIPTION
Closes #73 

### Fixed

- `black` config was not being used if it did not contain `[tool.snakefmt]` [#73]
- better handling of `black.FileMode` params [#73]