### PR TITLE
Vim plugin and new snakefmt configuration code

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ Options:
 from a `pyproject.toml` file. In addition, it will also load any [`black`
 configurations][black-config] you have in the same file.
 
-By default, `snakefmt` will search in your current directory for a file named
-`pyproject.toml`. If your configuration file is located somewhere else or called
-something different, then specify the location with `--config`.
+By default, `snakefmt` will search in the parent directories of the formatted file(s)
+for a file called `pyproject.toml` and use any configuration there. 
+If your configuration file is located somewhere else or called something different, 
+specify it using `--config`.
 
 Any options you pass on the command line will take precedence over default values in the
 configuration file.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ design and specifications of [Black][black].
   - [Conda](#conda)
   - [Containers](#containers)
   - [Local](#local)
-  - [Github Actions](#github-actions)
 - [Example File](#example-file)
 - [Usage](#usage)
   - [Basic Usage](#basic-usage)
   - [Full Usage](#full-usage)
 - [Configuration](#configuration)
-- [Editor Integration](#editor-integration)
+- [Integration](#integration)
+    - [Github Actions](#github-actions)
+    - [Editor Integration](#editor-integration)
 - [Plug Us](#plug-us)
 - [Changes](#changes)
 - [Contributing](#contributing)
@@ -95,47 +96,6 @@ poetry install
 # activate the environment so snakefmt is available on your PATH
 poetry shell
 ```
-
-### GitHub Actions
-
-[GitHub Actions](https://github.com/features/actions) in combination with [super-linter](https://github.com/github/super-linter) allows you to automatically run `snakefmt` on all Snakefiles in your repository e.g. whenever you push a new commit.
-
-To do so, create the file `.github/workflows/linter.yml` in your repository:
-```yaml
----
-name: Lint Code Base
-
-on:
-  push:
-  pull_request:
-    branches: [master]
-
-jobs:
-  build:
-    name: Lint Code Base
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-
-      - name: Lint Code Base
-        uses: github/super-linter@v3
-        env:
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          VALIDATE_SNAKEMAKE_SNAKEFMT: true
-```
-
-Additional configuration parameters can be specified by creating `.github/linters/.snakefmt.toml`:
-```toml
-[tool.black]
-skip_string_normalization = true
-```
-
-For more information check the `super-linter` readme.
 
 ## Example File
 
@@ -326,7 +286,50 @@ files for formatting - this effectively runs `black` on them. `snakefmt` will al
 on the `[tool.black]` settings, internally, to `black`.
 
 
-## Editor Integration
+## Integration
+
+### GitHub Actions
+
+[GitHub Actions](https://github.com/features/actions) in combination with [super-linter](https://github.com/github/super-linter) allows you to automatically run `snakefmt` on all Snakefiles in your repository e.g. whenever you push a new commit.
+
+To do so, create the file `.github/workflows/linter.yml` in your repository:
+```yaml
+---
+name: Lint Code Base
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          VALIDATE_SNAKEMAKE_SNAKEFMT: true
+```
+
+Additional configuration parameters can be specified by creating `.github/linters/.snakefmt.toml`:
+```toml
+[tool.black]
+skip_string_normalization = true
+```
+
+For more information check the `super-linter` readme.
+
+### Editor Integration
 
 For instructions on how to integrate `snakefmt` into your editor of choice, refer to
 [`docs/editor_integration.md`](docs/editor_integration.md)

--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -65,15 +65,18 @@ $ where snakefmt
 
 ## Vim
 
+Credit: plugin inspired by
+[black](https://github.com/psf/black/blob/master/plugin/black.vim)
+
 1. Install the plugin.
 
-Recommended way is via a plugin manager, eg [vim-plug](https://github.com/junegunn/vim-plug):
+    Recommended way is via a plugin manager, eg [vim-plug](https://github.com/junegunn/vim-plug):
 
     ```
     Plug 'snakemake/snakefmt' 
     ```
 
-or [Vundle](https://github.com/VundleVim/Vundle.vim):
+    or [Vundle](https://github.com/VundleVim/Vundle.vim):
 
     ```
     Plugin 'snakemake/snakefmt'
@@ -81,13 +84,13 @@ or [Vundle](https://github.com/VundleVim/Vundle.vim):
 
 2. That's it! Run `:Snakefmt` to format a buffer, and `:SnakefmtVersion` for version info.
 
-If you do not run Vim 7.0+ built with Python3.6+ support, or you have not installed `snakefmt`, those commands will complain.
+    If you do not run Vim 7.0+ built with Python3.6+ support, or you have not installed `snakefmt`, those commands will complain.
 
 3. If you want to format your file automatically when saving it, write this in your vimrc:
 
-```
-au BufNewFile,BufRead Snakefile,*.smk set filetype=snakemake
-au FileType snakemake autocmd BufWritePre <buffer> execute ':Snakefmt'
-```
+    ```
+    au BufNewFile,BufRead Snakefile,*.smk set filetype=snakemake
+    au FileType snakemake autocmd BufWritePre <buffer> execute ':Snakefmt'
+    ```
 
 4. If you additionally want syntax highlighting on your snakemake files, install snakemake's [syntax highlighter](https://github.com/snakemake/snakemake/tree/master/misc/vim)!

--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -10,6 +10,7 @@ already.**
 
 # Table of Contents
 - [PyCharm/JetBrains IDEA](#pycharmjetbrains-idea)
+- [Vim](#Vim)
 
 
 ## PyCharm/JetBrains IDEA
@@ -62,3 +63,31 @@ $ where snakefmt
 
    - Uncheck "Auto-save edited files to trigger the watcher" in Advanced Options
 
+## Vim
+
+1. Install the plugin.
+
+Recommended way is via a plugin manager, eg [vim-plug](https://github.com/junegunn/vim-plug):
+
+    ```
+    Plug 'snakemake/snakefmt' 
+    ```
+
+or [Vundle](https://github.com/VundleVim/Vundle.vim):
+
+    ```
+    Plugin 'snakemake/snakefmt'
+    ```
+
+2. That's it! Run `:Snakefmt` to format a buffer, and `:SnakefmtVersion` for version info.
+
+If you do not run Vim 7.0+ built with Python3.6+ support, or you have not installed `snakefmt`, those commands will complain.
+
+3. If you want to format your file automatically when saving it, write this in your vimrc:
+
+```
+au BufNewFile,BufRead Snakefile,*.smk set filetype=snakemake
+au FileType snakemake autocmd BufWritePre <buffer> execute ':Snakefmt'
+```
+
+4. If you additionally want syntax highlighting on your snakemake files, install snakemake's [syntax highlighter](https://github.com/snakemake/snakemake/tree/master/misc/vim)!

--- a/plugin/snakefmt.vim
+++ b/plugin/snakefmt.vim
@@ -1,0 +1,85 @@
+" Author: Brice Letcher
+" Requires: Vim Ver7.0+
+" Version:  1.0
+"
+" Documentation:
+"   This plugin formats Snakemake files.
+"   It is heavily inspired by black's vim plugin for Python: https://github.com/psf/black/blob/master/plugin/black.vim. All credit to its author Łukasz Langa.
+"
+" History:
+"  1.0:
+"    - initial version
+
+func! __Set_SNAKEFMT_MISSING(message)
+    command! Snakefmt echom a:message
+    command! SnakefmtVersion echom a:message
+endfunc
+    
+if v:version < 700 || !has('python3')
+    __Set_SNAKEFMT_MISSING("The snakemake.vim plugin requires vim7.0+ with Python 3.6 support.")
+    finish
+endif
+
+if exists("g:load_snakefmt")
+   finish
+endif
+
+python3 << EndPython3
+import sys
+import vim
+import time
+from io import StringIO
+
+try:
+    from snakefmt import __version__ as snakefmt_version
+    from snakefmt.snakefmt import read_snakefmt_config, DEFAULT_LINE_LENGTH
+    from snakefmt.formatter import Formatter
+    from snakefmt.parser.parser import Snakefile
+except ModuleNotFoundError:
+    error_message="snakefmt not found. Is snakefmt installed?"
+    def Snakefmt():
+        print(error_message)
+    def SnakefmtVersion():
+        print(error_message)
+else:
+    from black import find_pyproject_toml
+
+    def Snakefmt():
+      start = time.time()
+      pyproject_toml: Optional[str] = find_pyproject_toml(vim.eval("fnamemodify(getcwd(), ':t')"))
+      config = {"line_length": DEFAULT_LINE_LENGTH}
+      config.update(read_snakefmt_config(pyproject_toml))
+
+      buffer_str = '\n'.join(vim.current.buffer) + '\n'
+      try:
+        snakefile = Snakefile(StringIO(buffer_str))
+        formatter = Formatter(snakefile, line_length=config["line_length"], black_config_file=pyproject_toml)
+        new_buffer_str = formatter.get_formatted()
+      except Exception as exc:
+        print(exc)
+      else:
+        current_buffer = vim.current.window.buffer
+        cursors = []
+        for i, tabpage in enumerate(vim.tabpages):
+          if tabpage.valid:
+            for j, window in enumerate(tabpage.windows):
+              if window.valid and window.buffer == current_buffer:
+                cursors.append((i, j, window.cursor))
+        vim.current.buffer[:] = new_buffer_str.split('\n')[:-1]
+        for i, j, cursor in cursors:
+          window = vim.tabpages[i].windows[j]
+          try:
+            window.cursor = cursor
+          except vim.error:
+            window.cursor = (len(window.buffer), 0)
+        print(f'Reformatted with snakefmt in {time.time() - start:.4f}s.')
+
+    def SnakefmtVersion():
+      print(f'snakefmt version {snakefmt_version} on Python {sys.version}.')
+
+EndPython3
+
+let g:load_snakefmt = "py1.0"
+
+command! Snakefmt :py3 Snakefmt()
+command! SnakefmtVersion :py3 SnakefmtVersion()

--- a/plugin/snakefmt.vim
+++ b/plugin/snakefmt.vim
@@ -29,7 +29,7 @@ from io import StringIO
 
 try:
     from snakefmt import __version__ as snakefmt_version
-    from snakefmt.snakefmt import read_snakefmt_config, DEFAULT_LINE_LENGTH
+    from snakefmt.snakefmt import read_snakefmt_config, find_pyproject_toml, DEFAULT_LINE_LENGTH
     from snakefmt.formatter import Formatter
     from snakefmt.parser.parser import Snakefile
 except ModuleNotFoundError:
@@ -39,11 +39,11 @@ except ModuleNotFoundError:
     def SnakefmtVersion():
         print(error_message)
 else:
-    from black import find_pyproject_toml
 
     def Snakefmt():
       start = time.time()
-      pyproject_toml: Optional[str] = find_pyproject_toml(vim.eval("fnamemodify(getcwd(), ':t')"))
+      source_file = (vim.eval("expand('%:p')"),)
+      pyproject_toml = find_pyproject_toml(source_file)
       config = read_snakefmt_config(pyproject_toml)
       line_length = config.get("line_length", None)
 

--- a/plugin/snakefmt.vim
+++ b/plugin/snakefmt.vim
@@ -44,13 +44,13 @@ else:
     def Snakefmt():
       start = time.time()
       pyproject_toml: Optional[str] = find_pyproject_toml(vim.eval("fnamemodify(getcwd(), ':t')"))
-      config = {"line_length": DEFAULT_LINE_LENGTH}
-      config.update(read_snakefmt_config(pyproject_toml))
+      config = read_snakefmt_config(pyproject_toml)
+      line_length = config.get("line_length", None)
 
       buffer_str = '\n'.join(vim.current.buffer) + '\n'
       try:
         snakefile = Snakefile(StringIO(buffer_str))
-        formatter = Formatter(snakefile, line_length=config["line_length"], black_config_file=pyproject_toml)
+        formatter = Formatter(snakefile, line_length=line_length, black_config_file=pyproject_toml)
         new_buffer_str = formatter.get_formatted()
       except Exception as exc:
         print(exc)

--- a/plugin/snakefmt.vim
+++ b/plugin/snakefmt.vim
@@ -4,19 +4,16 @@
 "
 " Documentation:
 "   This plugin formats Snakemake files.
-"   It is heavily inspired by black's vim plugin for Python: https://github.com/psf/black/blob/master/plugin/black.vim. All credit to its author Łukasz Langa.
+"   It is inspired by black's vim plugin for Python: https://github.com/psf/black/blob/master/plugin/black.vim. Credit to its author Łukasz Langa.
 "
 " History:
 "  1.0:
 "    - initial version
 
-func! __Set_SNAKEFMT_MISSING(message)
-    command! Snakefmt echom a:message
-    command! SnakefmtVersion echom a:message
-endfunc
-    
 if v:version < 700 || !has('python3')
-    __Set_SNAKEFMT_MISSING("The snakemake.vim plugin requires vim7.0+ with Python 3.6 support.")
+    let g:snakefmt_missing = "The snakemake.vim plugin requires vim7.0+ with Python 3.6 support."
+    command! Snakefmt echom g:snakefmt_missing
+    command! SnakefmtVersion echom g:snakefmt_missing
     finish
 endif
 

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -26,10 +26,10 @@ PathLike = Union[Path, str]
 rule_like_formatted = {"rule", "checkpoint"}
 
 triple_quote_matcher = re.compile(
-    r"^\s*(\w?\"{3}.*?\"{3})|^\s*(\w?'{3}.*?'{3})", re.DOTALL | re.MULTILINE,
+    r"^\s*(\w?\"{3}.*?\"{3})|^\s*(\w?'{3}.*?'{3})", re.DOTALL | re.MULTILINE
 )
 contextual_matcher = re.compile(
-    r"(.*)^(if|elif|else|with|for|while)(.*)(:.*)", re.S | re.M,
+    r"(.*)^(if|elif|else|with|for|while)(.*)(:.*)", re.S | re.M
 )
 
 
@@ -41,19 +41,22 @@ class Formatter(Parser):
     def __init__(
         self,
         snakefile: TokenIterator,
-        line_length: int = DEFAULT_LINE_LENGTH,
+        line_length: Optional[int] = None,
         black_config_file: Optional[PathLike] = None,
     ):
-        self._line_length: int = line_length
+        self._line_length: int = DEFAULT_LINE_LENGTH
         self.result: str = ""
         self.lagging_comments: str = ""
         self.no_formatting_yet: bool = True
         self.last_recognised_keyword = ""
 
         if black_config_file is None:
-            self.black_mode = black.FileMode(line_length=self.line_length)
+            self.black_mode = black.FileMode()
         else:
             self.black_mode = self.read_black_config(black_config_file)
+        if line_length is not None:
+            self._line_length = line_length
+            self.black_mode.line_length = line_length
 
         super().__init__(snakefile)  # Call to parse snakefile
 
@@ -148,9 +151,7 @@ class Formatter(Parser):
         # Only stick together separated single-parm keywords when separated by comments
         if not all(map(comment_start, self.buffer.splitlines())):
             self.last_recognised_keyword = ""
-        self.add_newlines(
-            self.target_indent, formatted, final_flush, in_global_context,
-        )
+        self.add_newlines(self.target_indent, formatted, final_flush, in_global_context)
         self.buffer = ""
 
     def process_keyword_context(self, in_global_context: bool):
@@ -163,7 +164,7 @@ class Formatter(Parser):
         self.last_recognised_keyword = self.context.keyword_name
 
     def process_keyword_param(
-        self, param_context: ParameterSyntax, in_global_context: bool,
+        self, param_context: ParameterSyntax, in_global_context: bool
     ):
         self.add_newlines(
             param_context.target_indent - 1,
@@ -209,11 +210,11 @@ class Formatter(Parser):
             indented += first
             if len(all_lines) > 2:
                 middle = textwrap.indent(
-                    textwrap.dedent("".join(all_lines[1:-1])), used_indent,
+                    textwrap.dedent("".join(all_lines[1:-1])), used_indent
                 )
                 indented += middle
             if len(all_lines) > 1:
-                last = textwrap.indent(textwrap.dedent(all_lines[-1]), used_indent,)
+                last = textwrap.indent(textwrap.dedent(all_lines[-1]), used_indent)
                 indented += last
             pos = match.end()
         indented += textwrap.indent(string[pos:], used_indent)
@@ -277,7 +278,7 @@ class Formatter(Parser):
 
         for elem in parameters.all_params:
             result += self.format_param(
-                elem, target_indent, inline_fmting, single_param,
+                elem, target_indent, inline_fmting, single_param
             )
         return result
 

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 import black
 import toml
 
+from snakefmt import DEFAULT_LINE_LENGTH
 from snakefmt.exceptions import InvalidParameterSyntax, InvalidPython, MalformattedToml
 from snakefmt.parser.grammar import SnakeRule
 from snakefmt.parser.parser import Parser
@@ -49,7 +50,7 @@ class Formatter(Parser):
         self.last_recognised_keyword = ""
 
         if black_config_file is None:
-            self.black_mode = black.FileMode()
+            self.black_mode = black.FileMode(line_length=DEFAULT_LINE_LENGTH)
         else:
             self.black_mode = self.read_black_config(black_config_file)
 
@@ -83,6 +84,8 @@ class Formatter(Parser):
                 continue
 
             snakecase_config[key] = val
+        if "line_length" not in snakecase_config:
+            snakecase_config["line_length"] = DEFAULT_LINE_LENGTH
 
         return black.FileMode(**snakecase_config)
 

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -39,6 +39,8 @@ def construct_regex(regex: str) -> Pattern[str]:
 
 def read_snakefmt_config(path: Optional[str]) -> Dict[str, str]:
     """Parse Snakefmt configuration from provided toml."""
+    if path is None:
+        return dict()
     try:
         config_toml = toml.load(path)
         config = config_toml.get("tool", {}).get("snakefmt", {})
@@ -73,7 +75,7 @@ def inject_snakefmt_config(
 
 
 def get_snakefiles_in_dir(
-    path: Path, include: Pattern[str], exclude: Pattern[str], gitignore: PathSpec,
+    path: Path, include: Pattern[str], exclude: Pattern[str], gitignore: PathSpec
 ) -> Iterator[Path]:
     """Generate all files under `path` whose paths are not excluded by the
     `exclude` regex, but are included by the `include` regex.
@@ -113,10 +115,9 @@ def get_snakefiles_in_dir(
 @click.option(
     "-l",
     "--line-length",
-    default=DEFAULT_LINE_LENGTH,
-    show_default=True,
+    default=None,
     type=int,
-    help="Lines longer than INT will be wrapped.",
+    help=f"Lines longer than INT will be wrapped. [default: {DEFAULT_LINE_LENGTH}]",
     metavar="INT",
 )
 @click.option(

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -37,12 +37,11 @@ def construct_regex(regex: str) -> Pattern[str]:
     )
 
 
-def read_snakefmt_defaults_from_pyproject_toml(
+def read_snakefmt_config(
     ctx: click.Context, param: click.Parameter, value: Optional[str] = None
 ) -> Optional[str]:
-    """Inject Snakefmt configuration from "pyproject.toml" into defaults in `ctx`.
-    Returns the path to a successfully found and read configuration file, None
-    otherwise.
+    """Parse Snakefmt configuration from provided toml, or "pyproject.toml" by default.
+    Returns the path to a found and read configuration file, None otherwise.
     """
     if not value:
         path = Path("pyproject.toml")
@@ -52,8 +51,8 @@ def read_snakefmt_defaults_from_pyproject_toml(
             return None
 
     try:
-        pyproject_toml = toml.load(value)
-        config = pyproject_toml.get("tool", {}).get("snakefmt", {})
+        config_toml = toml.load(value)
+        config = config_toml.get("tool", {}).get("snakefmt", {})
     except (toml.TomlDecodeError, OSError) as error:
         raise click.FileError(
             filename=value, hint=f"Error reading configuration file: {error}"
@@ -183,7 +182,7 @@ def get_snakefiles_in_dir(
     ),
     metavar="PATH",
     is_eager=True,
-    callback=read_snakefmt_defaults_from_pyproject_toml,
+    callback=read_snakefmt_config,
     help=(
         "Read configuration from PATH. By default, will try to read from "
         "`./pyproject.toml`"

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -38,11 +38,11 @@ def construct_regex(regex: str) -> Pattern[str]:
 
 
 def read_snakefmt_config(path: Optional[str]) -> Dict[str, str]:
-    """Parse Snakefmt configuration from provided toml.
-    """
+    """Parse Snakefmt configuration from provided toml."""
     try:
         config_toml = toml.load(path)
         config = config_toml.get("tool", {}).get("snakefmt", {})
+        config = {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
         return config
     except (toml.TomlDecodeError, OSError) as error:
         raise click.FileError(
@@ -68,9 +68,7 @@ def inject_snakefmt_config(
 
     if ctx.default_map is None:
         ctx.default_map = {}
-    ctx.default_map.update(  # type: ignore  # bad types in .pyi
-        {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
-    )
+    ctx.default_map.update(config)  # type: ignore  # bad types in .pyi
     return config_file
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,10 @@
 from io import StringIO
 
-from snakefmt import DEFAULT_LINE_LENGTH
 from snakefmt.formatter import Formatter
 from snakefmt.parser.parser import Snakefile
 
 
-def setup_formatter(snake: str, line_length: int = DEFAULT_LINE_LENGTH):
+def setup_formatter(snake: str, line_length: int = None, black_config_file=None):
     stream = StringIO(snake)
     smk = Snakefile(stream)
-    return Formatter(smk, line_length=line_length)
+    return Formatter(smk, line_length=line_length, black_config_file=black_config_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ import pytest
 
 from snakefmt.exceptions import MalformattedToml
 from snakefmt.formatter import TAB
-from snakefmt.snakefmt import main, read_snakefmt_defaults_from_pyproject_toml
+from snakefmt.snakefmt import main, read_snakefmt_config
 from tests import setup_formatter
 
 
@@ -74,7 +74,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        return_val = read_snakefmt_defaults_from_pyproject_toml(ctx, param, value)
+        return_val = read_snakefmt_config(ctx, param, value)
 
         assert return_val is None
 
@@ -93,9 +93,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
-            ctx, param, value
-        )
+        actual_config_path = read_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -111,9 +109,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
-            ctx, param, value
-        )
+        actual_config_path = read_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -133,9 +129,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
-            ctx, param, value
-        )
+        actual_config_path = read_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -152,9 +146,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
         param = mock.MagicMock()
 
-        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
-            ctx, param, value=str(pyproject)
-        )
+        actual_config_path = read_snakefmt_config(ctx, param, value=str(pyproject))
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -172,9 +164,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = str(pyproject)
 
-        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
-            ctx, param, value
-        )
+        actual_config_path = read_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -194,9 +184,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = str(snakefmt_config)
 
-        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
-            ctx, param, value
-        )
+        actual_config_path = read_snakefmt_config(ctx, param, value)
         expected_config_path = str(snakefmt_config)
 
         assert actual_config_path == expected_config_path
@@ -215,7 +203,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         value = None
 
         with pytest.raises(click.FileError):
-            read_snakefmt_defaults_from_pyproject_toml(ctx, param, value)
+            read_snakefmt_config(ctx, param, value)
 
 
 class TestReadBlackConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,9 +14,8 @@ from tests import setup_formatter
 class TestConfigAdherence:
     def test_config_adherence_for_python_outside_rules(self, cli_runner, tmp_path):
         stdin = "include: 'a'\nlist_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
-        line_length = 30
         config = tmp_path / "pyproject.toml"
-        config.write_text(f"[tool.snakefmt]\nline_length = {line_length}\n")
+        config.write_text("[tool.snakefmt]\nline_length = 30\n")
         params = ["--config", str(config), "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
@@ -44,46 +43,33 @@ list_of_lots_of_things = [
         stdin = (
             f"rule a:\n"
             f"{TAB}input:\n"
-            f"{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+            f"{TAB*2}list_of_lots_of_things=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\n"
         )
-        line_length = 30
-        config = tmp_path / "pyproject.toml"
-        config.write_text(f"[tool.snakefmt]\nline_length = {line_length}\n")
-        params = ["--config", str(config), "-"]
+        for line_length, expect_same in zip((200, 30), (True, False)):
+            config = tmp_path / "pyproject.toml"
+            with config.open("w") as fout:
+                fout.write(f"[tool.snakefmt]\nline_length = {line_length}\n")
+            params = ["--config", str(config), "-"]
 
-        actual = cli_runner.invoke(main, params, input=stdin)
+            actual = cli_runner.invoke(main, params, input=stdin)
 
-        assert actual.exit_code == 0
-
-        expected_output = (
-            "rule a:\n"
-            f"{TAB*1}input:\n"
-            f"{TAB*2}list_of_lots_of_things=[\n"
-            f"{TAB*3}1,\n{TAB*3}2,\n{TAB*3}3,\n{TAB*3}4,\n{TAB*3}5,\n"
-            f"{TAB*3}6,\n{TAB*3}7,\n{TAB*3}8,\n{TAB*3}9,\n{TAB*3}10,\n"
-            f"{TAB*2}],\n"
-        )
-
-        assert actual.output == expected_output
+            assert actual.exit_code == 0
+            if expect_same:
+                assert actual.output == stdin
+            else:
+                assert actual.output != stdin
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:
     def test_no_value_passed_and_no_pyproject_changes_nothing(self, testdir):
-        default_map = dict()
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        ctx = click.Context(click.Command("snakefmt"), default_map=dict())
         param = mock.MagicMock()
-        value = None
 
-        return_val = inject_snakefmt_config(ctx, param, value)
-
+        return_val = inject_snakefmt_config(ctx, param, config_file=None)
         assert return_val is None
+        assert ctx.default_map == dict()
 
-        actual_default_map = ctx.default_map
-        expected_default_map = dict()
-
-        assert actual_default_map == expected_default_map
-
-    def test_pyproject_present_but_empty_changes_nothing_returns_pyproject_path(
+    def test_pyproject_present_but_empty_noparams_injected_returns_pyproject_path(
         self, testdir
     ):
         pyproject = Path("pyproject.toml")
@@ -96,113 +82,60 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         assert actual_config_path == str(pyproject)
         assert ctx.default_map == dict()
 
-    def test_no_value_passed_and_pyproject_present_changes_default_line_length(
-        self, testdir
-    ):
+    def test_pyprojecttoml_automatically_detected_and_parsed(self, testdir):
         pyproject = Path("pyproject.toml")
-        pyproject.write_text("[tool.snakefmt]\nline_length = 4")
+        pyproject.write_text("[tool.snakefmt]\nline_length = 4\n" "foo = true")
         default_map = dict(line_length=88)
         ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
         param = mock.MagicMock()
-        value = None
 
-        actual_config_path = inject_snakefmt_config(ctx, param, value)
-        expected_config_path = str(pyproject)
+        parsed_config_file = inject_snakefmt_config(ctx, param, config_file=None)
+        assert parsed_config_file == str(pyproject)
 
-        assert actual_config_path == expected_config_path
+        expected_parameters = dict(line_length=4, foo=True)
+        assert ctx.default_map == expected_parameters
 
-        actual_default_map = ctx.default_map
-        expected_default_map = dict(line_length=4)
-
-        assert actual_default_map == expected_default_map
-
-    def test_no_value_passed_and_pyproject_present_unknown_param_adds_to_default_map(
-        self, testdir
-    ):
-        pyproject = Path("pyproject.toml")
-        pyproject.write_text("[tool.snakefmt]\nfoo = true")
-        default_map = dict()
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
-        param = mock.MagicMock()
-        value = None
-
-        actual_config_path = inject_snakefmt_config(ctx, param, value)
-        expected_config_path = str(pyproject)
-
-        assert actual_config_path == expected_config_path
-
-        actual_default_map = ctx.default_map
-        expected_default_map = dict(foo=True)
-
-        assert actual_default_map == expected_default_map
-
-    def test_value_passed_reads_from_path(self, testdir):
+    def test_passed_configfile_gets_parsed(self, testdir):
+        """The configfile is not names 'pyproject.toml',
+        so does not get parsed without being passed at CLI"""
         pyproject = Path("snakefmt.toml")
         pyproject.write_text("[tool.snakefmt]\nfoo = true")
-        default_map = dict()
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
         param = mock.MagicMock()
 
-        actual_config_path = inject_snakefmt_config(
+        ctx = click.Context(click.Command("snakefmt"), default_map=None)
+        parsed_config_file = inject_snakefmt_config(ctx, param, config_file=None)
+        assert parsed_config_file is None
+
+        parsed_config_file = inject_snakefmt_config(
             ctx, param, config_file=str(pyproject)
         )
-        expected_config_path = str(pyproject)
+        assert parsed_config_file == str(pyproject)
+        assert ctx.default_map == dict(foo=True)
 
-        assert actual_config_path == expected_config_path
-
-        actual_default_map = ctx.default_map
-        expected_default_map = dict(foo=True)
-
-        assert actual_default_map == expected_default_map
-
-    def test_value_passed_but_default_map_is_None_still_updates_defaults(self, testdir):
-        pyproject = Path("snakefmt.toml")
-        pyproject.write_text("[tool.snakefmt]\nfoo = true")
-        default_map = None
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
-        param = mock.MagicMock()
-        value = str(pyproject)
-
-        actual_config_path = inject_snakefmt_config(ctx, param, value)
-        expected_config_path = str(pyproject)
-
-        assert actual_config_path == expected_config_path
-
-        actual_default_map = ctx.default_map
-        expected_default_map = dict(foo=True)
-
-        assert actual_default_map == expected_default_map
-
-    def test_value_passed_in_overrides_pyproject(self, testdir):
+    def test_CLI_configfile_overrides_pyproject(self, testdir):
         snakefmt_config = Path("snakefmt.toml")
         snakefmt_config.write_text("[tool.snakefmt]\nfoo = true")
         pyproject = Path("pyproject.toml")
         pyproject.write_text("[tool.snakefmt]\n\nfoo = false\nline_length = 90")
-        default_map = dict()
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        ctx = click.Context(click.Command("snakefmt"), default_map=dict())
         param = mock.MagicMock()
-        value = str(snakefmt_config)
 
-        actual_config_path = inject_snakefmt_config(ctx, param, value)
-        expected_config_path = str(snakefmt_config)
+        inject_snakefmt_config(ctx, param, config_file=None)
+        expected_parameters = dict(foo=False, line_length=90)
+        assert ctx.default_map == expected_parameters
 
-        assert actual_config_path == expected_config_path
-
-        actual_default_map = ctx.default_map
-        expected_default_map = dict(foo=True)
-
-        assert actual_default_map == expected_default_map
+        ctx.default_map = dict()
+        inject_snakefmt_config(ctx, param, config_file=str(snakefmt_config))
+        expected_parameters = dict(foo=True)
+        assert ctx.default_map == expected_parameters
 
     def test_malformatted_toml_raises_error(self, testdir):
         pyproject = Path("pyproject.toml")
         pyproject.write_text("foo:bar,baz\n{dict}&&&&")
-        default_map = dict()
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        ctx = click.Context(click.Command("snakefmt"), default_map=dict())
         param = mock.MagicMock()
-        value = None
-
         with pytest.raises(click.FileError):
-            inject_snakefmt_config(ctx, param, value)
+            inject_snakefmt_config(ctx, param, None)
 
 
 class TestReadBlackConfig:
@@ -219,7 +152,6 @@ class TestReadBlackConfig:
 
         actual = formatter.read_black_config(path)
         expected = black.FileMode(line_length=formatter.line_length)
-
         assert actual == expected
 
     def test_config_exists_with_black_settings(self, tmp_path):
@@ -233,18 +165,23 @@ class TestReadBlackConfig:
 
         assert actual == expected
 
-    def test_config_exists_with_no_line_length_uses_snakefmt_line_length(
-        self, tmp_path
-    ):
-        line_length = 9
-        formatter = setup_formatter("", line_length=line_length)
+    def test_black_line_length_overriden_by_snakefmt_line_length(self, tmp_path):
+        snakefmt_line_length = 100
+        black_line_length = 10
         path = tmp_path / "config.toml"
-        path.write_text("[tool.black]\nstring_normalization = false")
+        path.write_text(f"[tool.black]\nline_length = {black_line_length}")
 
-        actual = formatter.read_black_config(path)
-        expected = black.FileMode(line_length=line_length, string_normalization=False)
+        formatter = setup_formatter("", black_config_file=str(path))
+        expected = black.FileMode(line_length=black_line_length)
+        assert formatter.black_mode == expected
 
-        assert actual == expected
+        # Now add in snakefmt line length
+        formatter = setup_formatter(
+            "", line_length=snakefmt_line_length, black_config_file=str(path)
+        )
+
+        expected = black.FileMode(line_length=snakefmt_line_length)
+        assert formatter.black_mode == expected
 
     def test_config_exists_with_invalid_black_options_ignores_it(self, tmp_path):
         formatter = setup_formatter("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ import pytest
 
 from snakefmt.exceptions import MalformattedToml
 from snakefmt.formatter import TAB
-from snakefmt.snakefmt import main, read_snakefmt_config
+from snakefmt.snakefmt import inject_snakefmt_config, main
 from tests import setup_formatter
 
 
@@ -74,7 +74,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        return_val = read_snakefmt_config(ctx, param, value)
+        return_val = inject_snakefmt_config(ctx, param, value)
 
         assert return_val is None
 
@@ -88,15 +88,12 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
     ):
         pyproject = Path("pyproject.toml")
         pyproject.touch()
-        default_map = dict()
-        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        ctx = click.Context(click.Command("snakefmt"), default_map=dict())
         param = mock.MagicMock()
-        value = None
 
-        actual_config_path = read_snakefmt_config(ctx, param, value)
-        expected_config_path = str(pyproject)
+        actual_config_path = inject_snakefmt_config(ctx, param, None)
 
-        assert actual_config_path == expected_config_path
+        assert actual_config_path == str(pyproject)
         assert ctx.default_map == dict()
 
     def test_no_value_passed_and_pyproject_present_changes_default_line_length(
@@ -109,7 +106,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        actual_config_path = read_snakefmt_config(ctx, param, value)
+        actual_config_path = inject_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -129,7 +126,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = None
 
-        actual_config_path = read_snakefmt_config(ctx, param, value)
+        actual_config_path = inject_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -146,7 +143,9 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
         param = mock.MagicMock()
 
-        actual_config_path = read_snakefmt_config(ctx, param, value=str(pyproject))
+        actual_config_path = inject_snakefmt_config(
+            ctx, param, config_file=str(pyproject)
+        )
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -164,7 +163,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = str(pyproject)
 
-        actual_config_path = read_snakefmt_config(ctx, param, value)
+        actual_config_path = inject_snakefmt_config(ctx, param, value)
         expected_config_path = str(pyproject)
 
         assert actual_config_path == expected_config_path
@@ -184,7 +183,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         param = mock.MagicMock()
         value = str(snakefmt_config)
 
-        actual_config_path = read_snakefmt_config(ctx, param, value)
+        actual_config_path = inject_snakefmt_config(ctx, param, value)
         expected_config_path = str(snakefmt_config)
 
         assert actual_config_path == expected_config_path
@@ -203,7 +202,7 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
         value = None
 
         with pytest.raises(click.FileError):
-            read_snakefmt_config(ctx, param, value)
+            inject_snakefmt_config(ctx, param, value)
 
 
 class TestReadBlackConfig:


### PR DESCRIPTION
This PR adds a vim plugin as per #62 and also streamlines config parsing. I did this to enforce better consistency of config parsing and to enable vim plugin to parse configuration just like snakefmt does.

# Added
* Vim plugin, with instructions on how to install and automatically run it.
  The vim plugin also reads toml configuration in the same way `snakefmt` does.
* New searching for default `pyproject.toml`. Before was based on current workdir,
  now based on formatted file(s) (passed as `src` param at CLI) location. Use black code for this. With unit tests.
# Modified
* Single `line_length` in the `Formatter` class. Previously black and snakefmt toml
`line_length`s were kept separate. Now both set it, and snakefmt's, if set, overrides black.
* Refactored toml parsing in `snakefmt.py` into 3 functions for use by vim plugin
* Configuration unit tests: 
    - less code by removing one-time variable setting, 
    - test where `line_length` is below and above line of code, and expect changes and no changes respectively.
* No longer use black's DEFAULT LINE LENGTH, always use snakefmt's. Add unit test asserting the two
are the same in case they ever diverge.
* Documentation:
    - README, make an "Integration" section including editor integration and github integration.
    - Vim plugin documentation
