### PR TITLE
Isolate plugin import try block, format with black

### DIFF
--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -94,3 +94,7 @@ Credit: plugin inspired by
     ```
 
 4. If you additionally want syntax highlighting on your snakemake files, install snakemake's [syntax highlighter](https://github.com/snakemake/snakemake/tree/master/misc/vim)!
+
+### Troubleshooting
+
+Under certain circumstances, import errors can occur when using a virtual environment due to _Black_ dependency imports. See the [_Black_ Vim integration docs](https://black.readthedocs.io/en/stable/editor_integration.html#vim) for more details and a potential solution.

--- a/plugin/snakefmt.vim
+++ b/plugin/snakefmt.vim
@@ -1,12 +1,14 @@
 " Author: Brice Letcher
 " Requires: Vim Ver7.0+
-" Version:  1.0
+" Version:  1.1
 "
 " Documentation:
 "   This plugin formats Snakemake files.
 "   It is inspired by black's vim plugin for Python: https://github.com/psf/black/blob/master/plugin/black.vim. Credit to its author Łukasz Langa.
 "
 " History:
+"  1.1:
+"    - Isolated import try block to snakefmt, formatted with black
 "  1.0:
 "    - initial version
 
@@ -29,50 +31,60 @@ from io import StringIO
 
 try:
     from snakefmt import __version__ as snakefmt_version
-    from snakefmt.snakefmt import read_snakefmt_config, find_pyproject_toml, DEFAULT_LINE_LENGTH
+except ModuleNotFoundError:
+    error_message = "snakefmt not found. Is snakefmt installed?"
+
+    def Snakefmt():
+        print(error_message)
+
+    def SnakefmtVersion():
+        print(error_message)
+
+
+else:
+    from snakefmt.snakefmt import (
+        read_snakefmt_config,
+        find_pyproject_toml,
+        DEFAULT_LINE_LENGTH,
+    )
     from snakefmt.formatter import Formatter
     from snakefmt.parser.parser import Snakefile
-except ModuleNotFoundError:
-    error_message="snakefmt not found. Is snakefmt installed?"
-    def Snakefmt():
-        print(error_message)
-    def SnakefmtVersion():
-        print(error_message)
-else:
 
     def Snakefmt():
-      start = time.time()
-      source_file = (vim.eval("expand('%:p')"),)
-      pyproject_toml = find_pyproject_toml(source_file)
-      config = read_snakefmt_config(pyproject_toml)
-      line_length = config.get("line_length", None)
+        start = time.time()
+        source_file = (vim.eval("expand('%:p')"),)
+        pyproject_toml = find_pyproject_toml(source_file)
+        config = read_snakefmt_config(pyproject_toml)
+        line_length = config.get("line_length", None)
 
-      buffer_str = '\n'.join(vim.current.buffer) + '\n'
-      try:
-        snakefile = Snakefile(StringIO(buffer_str))
-        formatter = Formatter(snakefile, line_length=line_length, black_config_file=pyproject_toml)
-        new_buffer_str = formatter.get_formatted()
-      except Exception as exc:
-        print(exc)
-      else:
-        current_buffer = vim.current.window.buffer
-        cursors = []
-        for i, tabpage in enumerate(vim.tabpages):
-          if tabpage.valid:
-            for j, window in enumerate(tabpage.windows):
-              if window.valid and window.buffer == current_buffer:
-                cursors.append((i, j, window.cursor))
-        vim.current.buffer[:] = new_buffer_str.split('\n')[:-1]
-        for i, j, cursor in cursors:
-          window = vim.tabpages[i].windows[j]
-          try:
-            window.cursor = cursor
-          except vim.error:
-            window.cursor = (len(window.buffer), 0)
-        print(f'Reformatted with snakefmt in {time.time() - start:.4f}s.')
+        buffer_str = "\n".join(vim.current.buffer) + "\n"
+        try:
+            snakefile = Snakefile(StringIO(buffer_str))
+            formatter = Formatter(
+                snakefile, line_length=line_length, black_config_file=pyproject_toml
+            )
+            new_buffer_str = formatter.get_formatted()
+        except Exception as exc:
+            print(exc)
+        else:
+            current_buffer = vim.current.window.buffer
+            cursors = []
+            for i, tabpage in enumerate(vim.tabpages):
+                if tabpage.valid:
+                    for j, window in enumerate(tabpage.windows):
+                        if window.valid and window.buffer == current_buffer:
+                            cursors.append((i, j, window.cursor))
+            vim.current.buffer[:] = new_buffer_str.split("\n")[:-1]
+            for i, j, cursor in cursors:
+                window = vim.tabpages[i].windows[j]
+                try:
+                    window.cursor = cursor
+                except vim.error:
+                    window.cursor = (len(window.buffer), 0)
+            print(f"Reformatted with snakefmt in {time.time() - start:.4f}s.")
 
     def SnakefmtVersion():
-      print(f'snakefmt version {snakefmt_version} on Python {sys.version}.')
+        print(f"snakefmt version {snakefmt_version} on Python {sys.version}.")
 
 EndPython3
 


### PR DESCRIPTION
First of all thanks for `snakefmt` and the Vim plugin! When I first attempted to install `snakefmt` into an existing `conda` env I ran into an issue where, when using Vim complied with Python 3, I would get the error (print statement):
```bash
snakefmt not found. Is snakefmt installed?
```
I was initially confused as I had just installed `snakefmt` and could use it from the command line. It turns out that the `try` block was catching a `ModuleNotFoundError` from _Black_ due to an import issue with `regex` as documented [here](https://black.readthedocs.io/en/stable/editor_integration.html#vim).

To avoid this, I moved all but the `snakefmt_version` import out of the try block so that the `snakefmt not found` print statement only occurs when `snakefmt` isn't installed. In case others run into the same _Black_ import issue, I also added a Troubleshooting section to the docs. Lastly, and this is a bit cheeky I realize, I formatted the plugin python code with _Black_. I tested the updated plugin code.