### PR TITLE
Adds pre-commit hook metadata.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: snakefmt
+  name: snakefmt
+  description: "Snakefmt: The uncompromising Snakemake formatter"
+  entry: snakefmt
+  language: python
+  language_version: python3
+  require_serial: true
+  files: \.smk$|Snakefile

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ from a `pyproject.toml` file. In addition, it will also load any [`black`
 configurations][black-config] you have in the same file.
 
 By default, `snakefmt` will search in the parent directories of the formatted file(s)
-for a file called `pyproject.toml` and use any configuration there. 
-If your configuration file is located somewhere else or called something different, 
+for a file called `pyproject.toml` and use any configuration there.
+If your configuration file is located somewhere else or called something different,
 specify it using `--config`.
 
 Any options you pass on the command line will take precedence over default values in the
@@ -329,6 +329,22 @@ skip_string_normalization = true
 ```
 
 For more information check the `super-linter` readme.
+
+### Pre-commit
+
+[Pre-commit](https://pre-commit.com/) is a framework for managing git pre-commit hooks. Using this framework you can run `snakefmt` whenever you commit a `Snakefile` or `*.smk` file. `Pre-commit` automatically creates an isolated virtual environment with `snakefmt` and will stop the commit if `snakefmt` needed to modify the file. You then review, stage, re-commit these changes. Pre-commit is especially useful if you don't have access to a CI/CD systems like GitHub actions.
+
+To do so, create the file `.pre-commit-config.yaml` in the root of your project directory with the following:
+
+```yaml
+repos:
+-    repo: https://github.com/snakemake/snakefmt
+     rev: 0.2.4 # Replace by any tag/version ≥0.2.4 : https://github.com/snakemake/snakefmt/releases
+     hooks:
+     -    id: snakefmt
+```
+
+Then [install pre-commit](https://pre-commit.com/#installation) and initialize the pre-commit hooks by running `pre-commit install` (Note you need to run this step once per clone of your repository). Additional pre-commit hooks can be found [here](https://pre-commit.com/hooks.html).
 
 ### Editor Integration
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ For more information check the `super-linter` readme.
 
 ### Pre-commit
 
-[Pre-commit](https://pre-commit.com/) is a framework for managing git pre-commit hooks. Using this framework you can run `snakefmt` whenever you commit a `Snakefile` or `*.smk` file. `Pre-commit` automatically creates an isolated virtual environment with `snakefmt` and will stop the commit if `snakefmt` needed to modify the file. You then review, stage, re-commit these changes. Pre-commit is especially useful if you don't have access to a CI/CD systems like GitHub actions.
+[Pre-commit](https://pre-commit.com/) is a framework for managing git pre-commit hooks. Using this framework you can run `snakefmt` whenever you commit a `Snakefile` or `*.smk` file. `Pre-commit` automatically creates an isolated virtual environment with `snakefmt` and will stop the commit if `snakefmt` would modify the file. You then review, stage, and re-commit these changes. Pre-commit is especially useful if you don't have access to a CI/CD system like GitHub actions.
 
 To do so, create the file `.pre-commit-config.yaml` in the root of your project directory with the following:
 


### PR DESCRIPTION
It would be nice if snakefmt would work as easily with [pre-commit ](https://pre-commit.com/) as black. This PR copies the .pre-commit-hooks.yaml from the black repository and modifies it for snakefmt. 

Users could then point directly at the snakefmt repository in their `.pre-commit-config.yaml` and have snakefmt automatically run on `*.smk` and `Snakefile`.

Here is an example of what the config would look like pointing at my repo.
```yaml
-   repo: https://github.com/jfear/snakefmt
    rev: b4e365145107371a20e24dc3808230fef24feacf
    hooks:
    -   id: snakefmt
```

I don't know if the maintainers would want to include this kind of metadata. However, since the psf/black has I thought I would ask.