### PR TITLE
Better comment formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ cur_commit.rst
 venv
 tmp_work
 .python-version
+tags

--- a/plugin/snakefmt.vim
+++ b/plugin/snakefmt.vim
@@ -42,7 +42,7 @@ except ModuleNotFoundError:
 
 
 else:
-    from snakefmt.snakefmt import (
+    from snakefmt.config import (
         read_snakefmt_config,
         find_pyproject_toml,
         DEFAULT_LINE_LENGTH,

--- a/snakefmt/config.py
+++ b/snakefmt/config.py
@@ -1,0 +1,86 @@
+"""
+Code for searching for and parsing snakefmt configuration files
+"""
+
+import inspect
+from typing import Dict, Iterable, Optional, Union
+from pathlib import Path
+
+import click
+import toml
+from black import find_project_root, FileMode
+
+from snakefmt import DEFAULT_LINE_LENGTH
+from snakefmt.exceptions import MalformattedToml
+
+PathLike = Union[Path, str]
+
+
+def find_pyproject_toml(start_path: Iterable[str]) -> Optional[str]:
+    root = find_project_root(start_path)
+    config_file = root / "pyproject.toml"
+    return str(config_file) if config_file.is_file() else None
+
+
+def read_snakefmt_config(path: Optional[str]) -> Dict[str, str]:
+    """Parse Snakefmt configuration from provided toml."""
+    if path is None:
+        return dict()
+    try:
+        config_toml = toml.load(path)
+        config = config_toml.get("tool", {}).get("snakefmt", {})
+        config = {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
+        return config
+    except (toml.TomlDecodeError, OSError) as error:
+        raise click.FileError(
+            filename=path, hint=f"Error reading configuration file: {error}"
+        )
+
+
+def inject_snakefmt_config(
+    ctx: click.Context, param: click.Parameter, config_file: Optional[str] = None
+) -> Optional[str]:
+    """
+    If no config file argument provided, parses "pyproject.toml" if one exists.
+    Injects any parsed configuration into the relevant parameters to the click `ctx`.
+    """
+    if config_file is None:
+        config_file = find_pyproject_toml(ctx.params.get("src", ()))
+
+    config = read_snakefmt_config(config_file)
+
+    if ctx.default_map is None:
+        ctx.default_map = {}
+    ctx.default_map.update(config)  # type: ignore  # bad types in .pyi
+    return config_file
+
+
+def read_black_config(path: Optional[PathLike]) -> FileMode:
+    """Parse Black configuration from provided toml."""
+    black_mode = FileMode(line_length=DEFAULT_LINE_LENGTH)
+    if path is None:
+        return black_mode
+    if not Path(path).is_file():
+        raise FileNotFoundError(f"{path} is not a file.")
+
+    try:
+        pyproject_toml = toml.load(path)
+        config = pyproject_toml.get("tool", {}).get("black", {})
+    except toml.TomlDecodeError as error:
+        raise MalformattedToml(error)
+
+    valid_black_filemode_params = inspect.getfullargspec(FileMode).args
+
+    for key, val in config.items():
+        # this is due to FileMode param being string_normalise, but CLI being
+        # skip_string_normalise - https://github.com/snakemake/snakefmt/issues/73
+        if key.startswith("skip"):
+            key = key[5:]
+            val = not val
+
+        key = key.replace("-", "_")
+        if key not in valid_black_filemode_params:
+            continue
+
+        setattr(black_mode, key, val)
+    return black_mode

--- a/snakefmt/config.py
+++ b/snakefmt/config.py
@@ -3,12 +3,12 @@ Code for searching for and parsing snakefmt configuration files
 """
 
 import inspect
-from typing import Dict, Iterable, Optional, Union
 from pathlib import Path
+from typing import Dict, Iterable, Optional, Union
 
 import click
 import toml
-from black import find_project_root, FileMode
+from black import FileMode, find_project_root
 
 from snakefmt import DEFAULT_LINE_LENGTH
 from snakefmt.exceptions import MalformattedToml

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -215,7 +215,6 @@ class Formatter(Parser):
     ) -> str:
         if inline_formatting:
             target_indent = 0
-        comments = f"\n{TAB * target_indent}".join(parameter.comments)
         val = str(parameter)
 
         try:
@@ -237,11 +236,13 @@ class Formatter(Parser):
             match_equal = re.match("(.*?) = (.*)", val, re.DOTALL)
             val = f"{match_equal.group(1)}={match_equal.group(2)}"
 
-        val = val.strip("\n")
-        if single_param:
-            result = f"{val}{comments}\n"
-        else:
-            result = f"{val},{comments}\n"
+        result = ""
+        if len(parameter.pre_comments) != 0:
+            result += "\n".join(parameter.pre_comments) + "\n" 
+        result += val.strip("\n")
+        if not single_param:
+            result += ","
+        result += "\n".join(parameter.post_comments) + "\n"
         return result
 
     def format_params(self, parameters: ParameterSyntax, in_rule: bool) -> str:

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -238,7 +238,7 @@ class Formatter(Parser):
 
         result = ""
         if len(parameter.pre_comments) != 0:
-            result += "\n".join(parameter.pre_comments) + "\n" 
+            result += "\n".join(parameter.pre_comments) + "\n"
         result += val.strip("\n")
         if not single_param:
             result += ","
@@ -248,7 +248,6 @@ class Formatter(Parser):
     def format_params(self, parameters: ParameterSyntax, in_rule: bool) -> str:
         target_indent = parameters.target_indent
         used_indent = TAB * (target_indent - 1)
-        result = f"{used_indent}{parameters.keyword_name}:{parameters.comment}"
 
         p_class = parameters.__class__
         single_param = issubclass(p_class, SingleParam)
@@ -257,10 +256,13 @@ class Formatter(Parser):
         if in_rule and p_class is not RuleInlineSingleParam:
             inline_fmting = False
 
+        result = f"{used_indent}{parameters.keyword_name}:"
         if inline_fmting:
             result += " "
+            if parameters.comment != "":
+                result = f"{used_indent}{parameters.comment.lstrip()}\n{result}"
         else:
-            result += "\n"
+            result += f"{parameters.comment}\n"
 
         for elem in parameters.all_params:
             result += self.format_param(

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -1,12 +1,13 @@
 import re
 import textwrap
-from copy import copy
 from ast import parse as ast_parse
+from copy import copy
 from typing import Optional
 
 import black
 
 import snakefmt.warnings as warnings
+from snakefmt.config import PathLike, read_black_config
 from snakefmt.exceptions import InvalidParameterSyntax, InvalidPython
 from snakefmt.parser.grammar import SnakeRule
 from snakefmt.parser.parser import Parser
@@ -20,7 +21,6 @@ from snakefmt.parser.syntax import (
     Syntax,
 )
 from snakefmt.types import TokenIterator
-from snakefmt.config import read_black_config, PathLike
 
 rule_like_formatted = {"rule", "checkpoint"}
 

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -19,6 +19,7 @@ QUOTES = {'"', "'"}
 BRACKETS_OPEN = {"(", "[", "{"}
 BRACKETS_CLOSE = {")", "]", "}"}
 TAB = "    "  # PEP8, indentation will be coded as 4 spaces
+COMMENT_SPACING = "  "  # PEP8, minimum of two spaces for inline comments
 
 
 def is_colon(token: Token):
@@ -136,7 +137,7 @@ class Syntax:
         self.token = next(snakefile)
 
         if self.token.type == tokenize.COMMENT:
-            self.comment = f" {self.token.string}"
+            self.comment = f"{COMMENT_SPACING}{self.token.string}"
             self.token = next(snakefile)
 
     @property
@@ -318,7 +319,10 @@ class ParameterSyntax(Syntax):
                 target = self.latest_pushed_param.comments
             else:
                 target = cur_param.comments
-            target.append(" " + self.token.string)
+            if len(target) == 0:
+                target.append(f"{COMMENT_SPACING}{self.token.string}")
+            else:
+                target.append(self.token.string)
         elif is_equal_sign(self.token) and not self.in_brackets:
             cur_param.to_key_val_mode(self.token)
         elif is_comma_sign(self.token) and not self.in_brackets and not self.in_lambda:

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -14,13 +14,13 @@ from snakefmt.exceptions import (
     TooManyParameters,
 )
 from snakefmt.types import (
-    TAB,
     COMMENT_SPACING,
+    TAB,
     Parameter,
     Token,
     TokenIterator,
-    line_nb,
     col_nb,
+    line_nb,
     not_empty,
 )
 
@@ -252,7 +252,7 @@ class KeywordSyntax(Syntax):
 
 
 class ParameterSyntax(Syntax):
-    """Parses snakemake keywords that accept values, eg 'input'"""
+    """Parses snakemake keywords that do not accept other keywords, eg 'input'"""
 
     def __init__(
         self,

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -318,9 +318,9 @@ class ParameterSyntax(Syntax):
             cur_param.add_comment(self.token.string, self.target_indent)
             return cur_param
         if is_newline(self.token):  # Special treatment for inline comments
-            if cur_param.fully_processed:
+            if not cur_param.is_empty():
                 cur_param.inline = False
-            elif cur_param.has_value():
+            if cur_param.has_value():
                 cur_param.add_elem(self.token)
             self.found_newline = True
             return cur_param

--- a/snakefmt/types.py
+++ b/snakefmt/types.py
@@ -13,11 +13,14 @@ class Token(NamedTuple):
     start: Tuple[int, int] = (-1, -1)
     end: Tuple[int, int] = (-1, -1)
 
+
 def line_nb(token: Token) -> int:
     return token.start[0]
 
+
 def col_nb(token: Token) -> int:
     return token.start[1]
+
 
 def not_empty(token: Token):
     return len(token.string) > 0 and not token.string.isspace()
@@ -52,7 +55,7 @@ class Parameter:
         return str(self) == ""
 
     def add_comment(self, comment: str, indent_level: int) -> None:
-        if self.is_empty(): 
+        if self.is_empty():
             self.pre_comments.append(f"{TAB * indent_level}{comment}")
         else:
             if self.inline:

--- a/snakefmt/types.py
+++ b/snakefmt/types.py
@@ -43,7 +43,7 @@ class Parameter:
         self.len = 0
         self.inline: bool = True
         self.fully_processed: bool = False
-        self._num_post_added = 0
+        self._has_inline_comment: bool = False
 
     def __repr__(self):
         if self.has_a_key():
@@ -56,16 +56,11 @@ class Parameter:
 
     def add_comment(self, comment: str, indent_level: int) -> None:
         if self.is_empty():
-            self.pre_comments.append(f"{TAB * indent_level}{comment}")
+            self.pre_comments.append(comment)
         else:
             if self.inline:
-                self.post_comments.append(f"{COMMENT_SPACING}{comment}")
-            else:
-                to_add = f"{TAB * indent_level}{comment}"
-                if self._num_post_added == 0:  # Make sure will not appear inline
-                    to_add = "\n" + to_add
-                self.post_comments.append(to_add)
-            self._num_post_added += 1
+                self._has_inline_comment = True
+            self.post_comments.append(comment)
 
     def has_a_key(self) -> bool:
         return len(self.key) > 0

--- a/snakefmt/warnings.py
+++ b/snakefmt/warnings.py
@@ -1,0 +1,17 @@
+import logging
+
+PEP8_BLOCK_COMMENTS = """PEP8 recommends block comments appear before what they describe
+(see https://www.python.org/dev/peps/pep-0008/#id30)"""
+
+
+def block_comment_below(keyword: str, line_nb: int):
+    msg = f'Keyword "{keyword}" at line {line_nb} has comments under a value.'
+    logging.warning(f"{msg}\n{PEP8_BLOCK_COMMENTS}")
+
+
+def comment_relocation(keyword: str, line_nb: int):
+    msg = (
+        f'Inline-formatted keyword "{keyword}" at line {line_nb} had its'
+        " comments relocated above it."
+    )
+    logging.warning(f"{msg}\n{PEP8_BLOCK_COMMENTS}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
-    return CliRunner()
+    return CliRunner(mix_stderr=False)
 
 
 pytest_plugins = "pytester"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,12 +8,13 @@ import pytest
 from snakefmt import DEFAULT_LINE_LENGTH
 from snakefmt.exceptions import MalformattedToml
 from snakefmt.formatter import TAB
-from snakefmt.snakefmt import (
+from snakefmt.config import (
     find_pyproject_toml,
     inject_snakefmt_config,
-    main,
     read_snakefmt_config,
+    read_black_config,
 )
+from snakefmt.snakefmt import main
 from tests import setup_formatter
 
 
@@ -185,7 +186,7 @@ class TestReadBlackConfig:
         formatter = setup_formatter("")
         path = tmp_path / "config.toml"
         with pytest.raises(FileNotFoundError):
-            formatter.read_black_config(path)
+            read_black_config(path)
 
     def test_empty_config_default_line_length_used(self, tmp_path):
         formatter = setup_formatter("")
@@ -200,8 +201,7 @@ class TestReadBlackConfig:
         black_line_length = 9
         path.write_text(f"[tool.black]\nline_length = {black_line_length}")
 
-        formatter.read_black_config(path)
-        actual = formatter.black_mode
+        actual = read_black_config(path)
         expected = black.FileMode(line_length=black_line_length)
 
         assert actual == expected
@@ -232,7 +232,7 @@ class TestReadBlackConfig:
         path = tmp_path / "config.toml"
         path.write_text("[tool.black]\nfoo = false")
 
-        formatter.read_black_config(path)
+        read_black_config(path)
         actual = formatter.black_mode
         expected = black.FileMode(line_length=DEFAULT_LINE_LENGTH)
 
@@ -244,7 +244,7 @@ class TestReadBlackConfig:
         path.write_text("[tool.black]\n{key}: I am not json:\n or yaml = false")
 
         with pytest.raises(MalformattedToml) as error:
-            formatter.read_black_config(path)
+            read_black_config(path)
 
         assert error.match("invalid character")
 
@@ -253,7 +253,7 @@ class TestReadBlackConfig:
         path = tmp_path / "config.toml"
         path.write_text("[tool.black]\nskip_string_normalization = false")
 
-        formatter.read_black_config(path)
+        read_black_config(path)
         actual = formatter.black_mode
         expected = black.FileMode(
             line_length=DEFAULT_LINE_LENGTH, string_normalization=True
@@ -266,7 +266,7 @@ class TestReadBlackConfig:
         path = tmp_path / "config.toml"
         path.write_text("[tool.black]\nskip-string-normalization = 0")
 
-        formatter.read_black_config(path)
+        read_black_config(path)
         actual = formatter.black_mode
         expected = black.FileMode(
             line_length=DEFAULT_LINE_LENGTH, string_normalization=True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,14 +6,14 @@ import click
 import pytest
 
 from snakefmt import DEFAULT_LINE_LENGTH
-from snakefmt.exceptions import MalformattedToml
-from snakefmt.formatter import TAB
 from snakefmt.config import (
     find_pyproject_toml,
     inject_snakefmt_config,
-    read_snakefmt_config,
     read_black_config,
+    read_snakefmt_config,
 )
+from snakefmt.exceptions import MalformattedToml
+from snakefmt.formatter import TAB
 from snakefmt.snakefmt import main
 from tests import setup_formatter
 
@@ -183,7 +183,6 @@ class TestReadSnakefmtDefaultsFromPyprojectToml:
 
 class TestReadBlackConfig:
     def test_config_doesnt_exist_raises_error(self, tmp_path):
-        formatter = setup_formatter("")
         path = tmp_path / "config.toml"
         with pytest.raises(FileNotFoundError):
             read_black_config(path)
@@ -196,7 +195,6 @@ class TestReadBlackConfig:
         assert formatter.black_mode == expected
 
     def test_read_black_config_settings(self, tmp_path):
-        formatter = setup_formatter("")
         path = tmp_path / "config.toml"
         black_line_length = 9
         path.write_text(f"[tool.black]\nline_length = {black_line_length}")
@@ -239,7 +237,6 @@ class TestReadBlackConfig:
         assert actual == expected
 
     def test_malformatted_toml_raises_error(self, tmp_path):
-        formatter = setup_formatter("")
         path = tmp_path / "config.toml"
         path.write_text("[tool.black]\n{key}: I am not json:\n or yaml = false")
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -8,8 +8,8 @@ from unittest import mock
 
 import pytest
 
-from snakefmt.parser.syntax import TAB, COMMENT_SPACING
 from snakefmt.parser.grammar import SingleParam, SnakeGlobal
+from snakefmt.parser.syntax import COMMENT_SPACING, TAB
 from tests import Formatter, Snakefile, setup_formatter
 
 
@@ -580,8 +580,10 @@ class TestCommentTreatment:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
-    @pytest.mark.xfail(reason="This is non-trivial to implement, and black does not align the comments like this,"
-            " but places them two spaces after each line. See #86.")
+    @pytest.mark.xfail(
+        reason="""This is non-trivial to implement, and black does no align the comments
+        like this, but places them two spaces after each line. See #86."""
+    )
     def test_aligned_comments_stay_untouched(self):
         snakecode = (
             "rule eval:                             # [hide]\n"
@@ -605,17 +607,21 @@ class TestCommentTreatment:
         )
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
-    
 
-    def test_inline_param_merges_comments(self):
+    def test_inline_formatted_params_relocate_inline_comments(self):
         snakecode = (
+            "include: # Include\n"
+            f"{TAB * 1}file.txt\n\n\n"
             "rule all:\n"
-            f"{TAB * 1}threads:  # comment 1\n"
-            f"{TAB * 2}8  # comment 2\n"
+            f"{TAB * 1}threads:  # Threads 1\n"
+            f"{TAB * 2}8  # Threads 2\n"
         )
         expected = (
+            "# Include\n"
+            f"include: file.txt\n\n\n"
             "rule all:\n"
-            f"{TAB * 1}threads: 8 # comment 1; comment 2\n"
+            f"{TAB * 1}# Threads 1\n"
+            f"{TAB * 1}threads: 8  # Threads 2\n"
         )
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == expected
@@ -630,7 +636,6 @@ class TestCommentTreatment:
         )
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
-
 
 
 class TestNewlineSpacing:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -580,6 +580,8 @@ class TestCommentTreatment:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
+    @pytest.mark.xfail(reason="This is non-trivial to implement, and black does not align the comments like this,"
+            " but places them two spaces after each line. See #86.")
     def test_aligned_comments_stay_untouched(self):
         snakecode = (
             "rule eval:                             # [hide]\n"
@@ -617,6 +619,17 @@ class TestCommentTreatment:
         )
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == expected
+
+    def test_no_inline_comments_stay_untouched(self):
+        snakecode = (
+            "rule all:\n"
+            f"{TAB * 1}input:\n"
+            f"{TAB * 2}p=2,\n"
+            f"{TAB * 2}#comment1\n"
+            f"{TAB * 2}#comment2\n"
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
 
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -626,6 +626,24 @@ class TestCommentTreatment:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == expected
 
+    def test_preceding_comments_in_inline_formatted_params_get_relocated(self):
+        snakecode = (
+            "rule all:\n"
+            f"{TAB * 1}# Threads1\n"
+            f"{TAB * 1}threads: # Threads2\n"
+            f"{TAB * 2}# Threads3\n"
+            f"{TAB * 2}8  # Threads 4\n"
+        )
+        expected = (
+            "rule all:\n"
+            f"{TAB * 1}# Threads1\n"
+            f"{TAB * 1}# Threads2\n"
+            f"{TAB * 1}# Threads3\n"
+            f"{TAB * 1}threads: 8  # Threads 4\n"
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == expected
+
     def test_no_inline_comments_stay_untouched(self):
         snakecode = (
             "rule all:\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,8 +19,10 @@ from snakefmt.exceptions import (
 from snakefmt.formatter import TAB
 from tests import Formatter, Snakefile, setup_formatter
 
+
 class TestSnakefileTokenizer:
     text = f"rule a:\n{TAB * 1}threads: 8"
+
     def test_snakefile_sequential_parsing(self):
         istream = StringIO(self.text)
         expected_sequence = istream.read().split()
@@ -44,9 +46,8 @@ class TestSnakefileTokenizer:
         result_sequence = list()
         for _ in range(3):
             result_sequence.append(next(snakefile).string)
-        expected_sequence = ["a",":","\n"]
+        expected_sequence = ["a", ":", "\n"]
         assert expected_sequence == result_sequence
-
 
 
 class TestKeywordSyntax:

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -18,13 +18,13 @@ class TestCLIBasic:
         params = []
         actual = cli_runner.invoke(main, params)
         assert actual.exit_code == 0
-        assert "Nothing to do" in actual.output
+        assert "Nothing to do" in actual.stderr
 
     def test_nonExistentParam_nonZeroExit(self, cli_runner):
         params = ["--fake"]
         actual = cli_runner.invoke(main, params)
         assert actual.exit_code != 0
-        assert "no such option" in actual.output
+        assert "no such option" in actual.stderr
 
     def test_invalidPath_nonZeroExit(self, cli_runner):
         params = ["fake.txt"]
@@ -33,21 +33,19 @@ class TestCLIBasic:
         expected_pattern = re.compile(
             r"Path [\'\"]{}[\'\"] does not exist".format(params[0])
         )
-        assert expected_pattern.search(actual.output)
+        assert expected_pattern.search(actual.stderr)
 
     def test_dashMixedWithFiles_nonZeroExit(self, cli_runner):
         params = ["-", str(Path().resolve())]
         actual = cli_runner.invoke(main, params)
         assert actual.exit_code != 0
-        assert "Cannot mix stdin (-) with other files" in actual.output
+        assert "Cannot mix stdin (-) with other files" in actual.stderr
 
     def test_stdinAsSrc_WritesToStdout(self, cli_runner):
         stdin = f"rule all:\n{TAB}input: 'c'"
         params = ["--verbose", "-"]
 
         actual = cli_runner.invoke(main, params, input=stdin)
-
-        print(actual.exception)
 
         assert actual.exit_code == 0
 


### PR DESCRIPTION
This PR mainly addresses #85, providing better formatting of comments.
It also adds code infrastructure for issuing warnings and ungetting tokens.

## Added
* Infrastructure for issuing warnings in warnings.py. Warnings introduced for comment formatting, as per #85.
* File-specific logging: warnings and errors during reformatting now automatically refer
  to the raising source file.
* Infrastructure to 'unget' parsed tokens. Not used yet, but useful to have. With tests.
## Fixed
(All these bugs documented in #85)
* Comments above keywords stay untouched
* Inline comments in inline-formatted keywords get relocated above keyword
* PEP8 inline comment formatting: use 2 spaces

With tests for each.
## Changed
* Refactored config-related code out of `snakefmt.py` and `formatter.py` to own source 
  file, `config.py`
