### PR TITLE
Support for snakemake ^6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Added
+
+* Support for module syntax: `module` keyword and `use rule` syntax ([#99][99])
+* Support for `containerized` keyword
+
+### Changed
+
+* Updated snakemake dependency to ^6.0.0 ([#99][99])
+
 ## [0.3.1]
 
 ### Fixed
@@ -170,4 +179,5 @@ is 40 character long, the line is 48 characters long. However, we were only pass
 [93]: https://github.com/snakemake/snakefmt/issues/93
 [96]: https://github.com/snakemake/snakefmt/issues/96
 [97]: https://github.com/snakemake/snakefmt/pull/97
+[99]: https://github.com/snakemake/snakefmt/issues/99
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,7 +97,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "configargparse"
-version = "1.2.3"
+version = "1.3"
 description = "A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables."
 category = "dev"
 optional = false
@@ -108,7 +108,7 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "coverage"
-version = "5.4"
+version = "5.5"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -150,6 +150,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "filelock"
+version = "3.0.12"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "flake8"
 version = "3.8.4"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -176,7 +184,7 @@ smmap = ">=3.0.1,<4"
 
 [[package]]
 name = "gitpython"
-version = "3.1.13"
+version = "3.1.14"
 description = "Python Git Library"
 category = "dev"
 optional = false
@@ -496,6 +504,23 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "smart-open"
+version = "4.2.0"
+description = "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)"
+category = "dev"
+optional = false
+python-versions = ">=3.6.*"
+
+[package.extras]
+all = ["boto3", "google-cloud-storage", "azure-storage-blob", "azure-common", "azure-core", "requests"]
+azure = ["azure-storage-blob", "azure-common", "azure-core"]
+gcp = ["google-cloud-storage"]
+http = ["requests"]
+s3 = ["boto3"]
+test = ["boto3", "google-cloud-storage", "azure-storage-blob", "azure-common", "azure-core", "requests", "mock", "moto[server] (==1.3.14)", "pathlib2", "responses", "boto3", "paramiko", "parameterizedtestcase", "pytest", "pytest-rerunfailures"]
+webhdfs = ["requests"]
+
+[[package]]
 name = "smmap"
 version = "3.0.5"
 description = "A pure Python implementation of a sliding window memory map manager"
@@ -505,7 +530,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "snakemake"
-version = "5.32.2"
+version = "6.0.1"
 description = "Snakemake is a workflow management system that aims to reduce the complexity of creating workflows by providing a fast and comfortable execution environment, together with a clean and modern specification language in python style. Snakemake workflows are essentially Python scripts extended by declarative code to define rules. Rules describe how to create output files from input files."
 category = "dev"
 optional = false
@@ -516,6 +541,7 @@ appdirs = "*"
 configargparse = "*"
 datrie = "*"
 docutils = "*"
+filelock = "*"
 gitpython = "*"
 jsonschema = "*"
 nbformat = "*"
@@ -524,6 +550,7 @@ pulp = ">=2.0"
 pyyaml = "*"
 ratelimiter = "*"
 requests = "*"
+smart_open = "*"
 toposort = "*"
 wrapt = "*"
 
@@ -625,7 +652,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "40f623208178077dc4b9a74a2c73afbedc07219c2d3657208e6a8cb67eaeee55"
+content-hash = "e0f48bbc09d7e88a06336fcf9c11d7e0f22ff761022ea3cf70fd8f40afdf096a"
 
 [metadata.files]
 amply = [
@@ -665,58 +692,61 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 configargparse = [
-    {file = "ConfigArgParse-1.2.3.tar.gz", hash = "sha256:edd17be986d5c1ba2e307150b8e5f5107aba125f3574dddd02c85d5cdcfd37dc"},
+    {file = "ConfigArgParse-1.3.tar.gz", hash = "sha256:0428b975ab6c48bb101ccb732e1b5cb616296e28268e032aa806f32b647a1cc1"},
 ]
 coverage = [
-    {file = "coverage-5.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6d9c88b787638a451f41f97446a1c9fd416e669b4d9717ae4615bd29de1ac135"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:66a5aae8233d766a877c5ef293ec5ab9520929c2578fd2069308a98b7374ea8c"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9754a5c265f991317de2bac0c70a746efc2b695cf4d49f5d2cddeac36544fb44"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:fbb17c0d0822684b7d6c09915677a32319f16ff1115df5ec05bdcaaee40b35f3"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:b7f7421841f8db443855d2854e25914a79a1ff48ae92f70d0a5c2f8907ab98c9"},
-    {file = "coverage-5.4-cp27-cp27m-win32.whl", hash = "sha256:4a780807e80479f281d47ee4af2eb2df3e4ccf4723484f77da0bb49d027e40a1"},
-    {file = "coverage-5.4-cp27-cp27m-win_amd64.whl", hash = "sha256:87c4b38288f71acd2106f5d94f575bc2136ea2887fdb5dfe18003c881fa6b370"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:c6809ebcbf6c1049002b9ac09c127ae43929042ec1f1dbd8bb1615f7cd9f70a0"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ba7ca81b6d60a9f7a0b4b4e175dcc38e8fef4992673d9d6e6879fd6de00dd9b8"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:89fc12c6371bf963809abc46cced4a01ca4f99cba17be5e7d416ed7ef1245d19"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a8eb7785bd23565b542b01fb39115a975fefb4a82f23d407503eee2c0106247"},
-    {file = "coverage-5.4-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:7e40d3f8eb472c1509b12ac2a7e24158ec352fc8567b77ab02c0db053927e339"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1ccae21a076d3d5f471700f6d30eb486da1626c380b23c70ae32ab823e453337"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:755c56beeacac6a24c8e1074f89f34f4373abce8b662470d3aa719ae304931f3"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:322549b880b2d746a7672bf6ff9ed3f895e9c9f108b714e7360292aa5c5d7cf4"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:60a3307a84ec60578accd35d7f0c71a3a971430ed7eca6567399d2b50ef37b8c"},
-    {file = "coverage-5.4-cp35-cp35m-win32.whl", hash = "sha256:1375bb8b88cb050a2d4e0da901001347a44302aeadb8ceb4b6e5aa373b8ea68f"},
-    {file = "coverage-5.4-cp35-cp35m-win_amd64.whl", hash = "sha256:16baa799ec09cc0dcb43a10680573269d407c159325972dd7114ee7649e56c66"},
-    {file = "coverage-5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2f2cf7a42d4b7654c9a67b9d091ec24374f7c58794858bff632a2039cb15984d"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:b62046592b44263fa7570f1117d372ae3f310222af1fc1407416f037fb3af21b"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:812eaf4939ef2284d29653bcfee9665f11f013724f07258928f849a2306ea9f9"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:859f0add98707b182b4867359e12bde806b82483fb12a9ae868a77880fc3b7af"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:04b14e45d6a8e159c9767ae57ecb34563ad93440fc1b26516a89ceb5b33c1ad5"},
-    {file = "coverage-5.4-cp36-cp36m-win32.whl", hash = "sha256:ebfa374067af240d079ef97b8064478f3bf71038b78b017eb6ec93ede1b6bcec"},
-    {file = "coverage-5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:84df004223fd0550d0ea7a37882e5c889f3c6d45535c639ce9802293b39cd5c9"},
-    {file = "coverage-5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1b811662ecf72eb2d08872731636aee6559cae21862c36f74703be727b45df90"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6b588b5cf51dc0fd1c9e19f622457cc74b7d26fe295432e434525f1c0fae02bc"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3fe50f1cac369b02d34ad904dfe0771acc483f82a1b54c5e93632916ba847b37"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:32ab83016c24c5cf3db2943286b85b0a172dae08c58d0f53875235219b676409"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:68fb816a5dd901c6aff352ce49e2a0ffadacdf9b6fae282a69e7a16a02dad5fb"},
-    {file = "coverage-5.4-cp37-cp37m-win32.whl", hash = "sha256:a636160680c6e526b84f85d304e2f0bb4e94f8284dd765a1911de9a40450b10a"},
-    {file = "coverage-5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:bb32ca14b4d04e172c541c69eec5f385f9a075b38fb22d765d8b0ce3af3a0c22"},
-    {file = "coverage-5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4d7165a4e8f41eca6b990c12ee7f44fef3932fac48ca32cecb3a1b2223c21f"},
-    {file = "coverage-5.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a565f48c4aae72d1d3d3f8e8fb7218f5609c964e9c6f68604608e5958b9c60c3"},
-    {file = "coverage-5.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fff1f3a586246110f34dc762098b5afd2de88de507559e63553d7da643053786"},
-    {file = "coverage-5.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a839e25f07e428a87d17d857d9935dd743130e77ff46524abb992b962eb2076c"},
-    {file = "coverage-5.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:6625e52b6f346a283c3d563d1fd8bae8956daafc64bb5bbd2b8f8a07608e3994"},
-    {file = "coverage-5.4-cp38-cp38-win32.whl", hash = "sha256:5bee3970617b3d74759b2d2df2f6a327d372f9732f9ccbf03fa591b5f7581e39"},
-    {file = "coverage-5.4-cp38-cp38-win_amd64.whl", hash = "sha256:03ed2a641e412e42cc35c244508cf186015c217f0e4d496bf6d7078ebe837ae7"},
-    {file = "coverage-5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:14a9f1887591684fb59fdba8feef7123a0da2424b0652e1b58dd5b9a7bb1188c"},
-    {file = "coverage-5.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9564ac7eb1652c3701ac691ca72934dd3009997c81266807aef924012df2f4b3"},
-    {file = "coverage-5.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:0f48fc7dc82ee14aeaedb986e175a429d24129b7eada1b7e94a864e4f0644dde"},
-    {file = "coverage-5.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:107d327071061fd4f4a2587d14c389a27e4e5c93c7cba5f1f59987181903902f"},
-    {file = "coverage-5.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:0cdde51bfcf6b6bd862ee9be324521ec619b20590787d1655d005c3fb175005f"},
-    {file = "coverage-5.4-cp39-cp39-win32.whl", hash = "sha256:c67734cff78383a1f23ceba3b3239c7deefc62ac2b05fa6a47bcd565771e5880"},
-    {file = "coverage-5.4-cp39-cp39-win_amd64.whl", hash = "sha256:c669b440ce46ae3abe9b2d44a913b5fd86bb19eb14a8701e88e3918902ecd345"},
-    {file = "coverage-5.4-pp36-none-any.whl", hash = "sha256:c0ff1c1b4d13e2240821ef23c1efb1f009207cb3f56e16986f713c2b0e7cd37f"},
-    {file = "coverage-5.4-pp37-none-any.whl", hash = "sha256:cd601187476c6bed26a0398353212684c427e10a903aeafa6da40c63309d438b"},
-    {file = "coverage-5.4.tar.gz", hash = "sha256:6d2e262e5e8da6fa56e774fb8e2643417351427604c2b177f8e8c5f75fc928ca"},
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
@@ -757,6 +787,10 @@ docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
+filelock = [
+    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
+    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+]
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
@@ -766,8 +800,8 @@ gitdb = [
     {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.13-py3-none-any.whl", hash = "sha256:c5347c81d232d9b8e7f47b68a83e5dc92e7952127133c5f2df9133f2c75a1b29"},
-    {file = "GitPython-3.1.13.tar.gz", hash = "sha256:8621a7e777e276a5ec838b59280ba5272dd144a18169c36c903d8b38b99f750a"},
+    {file = "GitPython-3.1.14-py3-none-any.whl", hash = "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b"},
+    {file = "GitPython-3.1.14.tar.gz", hash = "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -972,12 +1006,15 @@ six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
+smart-open = [
+    {file = "smart_open-4.2.0.tar.gz", hash = "sha256:d9f5a0f173ccb9bbae528db5a3804f57145815774f77ef755b9b0f3b4b2a9dcb"},
+]
 smmap = [
     {file = "smmap-3.0.5-py2.py3-none-any.whl", hash = "sha256:7bfcf367828031dc893530a29cb35eb8c8f2d7c8f2d0989354d75d24c8573714"},
     {file = "smmap-3.0.5.tar.gz", hash = "sha256:84c2751ef3072d4f6b2785ec7ee40244c6f45eb934d9e543e2c51f1bd3d54c50"},
 ]
 snakemake = [
-    {file = "snakemake-5.32.2.tar.gz", hash = "sha256:ff35f3c5d283c5b38a926b943f18aa732cc8af4bd1f59471907ef3adda1b018c"},
+    {file = "snakemake-6.0.1.tar.gz", hash = "sha256:9da2191b688882f505fa12b0e1a4cf5bdf78dcf80811fdf011dccee0465cf86b"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ importlib_metadata = "^1.7.0"
 pytest = "^5.2"
 pytest-cov = "^2.8.1"
 flake8 = "^3.7.9"
-snakemake = "^5.32.2"
+snakemake = "^6.0.0"
 isort = "^5.1.0"
 
 [tool.poetry.urls]

--- a/snakefmt/exceptions.py
+++ b/snakefmt/exceptions.py
@@ -14,8 +14,24 @@ class EmptyContextError(Exception):
     pass
 
 
-class NamedKeywordError(Exception):
-    pass
+def NotAnIdentifierError(line_nb: str, identifier: str, keyword_line: str):
+    raise SyntaxError(
+        f"{line_nb}'{identifier}' in '{keyword_line}' is not a valid identifier"
+    )
+
+
+def ColonError(line_nb: str, identifier: str, keyword_line: str):
+    raise SyntaxError(
+        f"{line_nb}Colon (not '{identifier}') expected after " f"'{keyword_line}'"
+    )
+
+
+def NewlineError(line_nb: str, keyword_line: str):
+    raise SyntaxError((f"{line_nb}Newline expected after keyword " f"'{keyword_line}'"))
+
+
+def SyntaxFormError(line_nb: str, keyword_line: str, syntax_form: str):
+    raise SyntaxError(f"{line_nb}'{keyword_line}' not of form '{syntax_form}'")
 
 
 class InvalidParameterSyntax(Exception):

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -112,9 +112,10 @@ class Formatter(Parser):
     def process_keyword_context(self, in_global_context: bool):
         cur_indent = self.syntax.cur_indent
         self.add_newlines(cur_indent, in_global_context=in_global_context)
-        formatted = (
-            f"{TAB * cur_indent}{self.syntax.keyword_line}:{self.syntax.comment}\n"
-        )
+        formatted = f"{TAB * cur_indent}{self.syntax.keyword_line}"
+        if self.syntax.enter_context:
+            formatted += ":"
+        formatted += f"{self.syntax.comment}\n"
         self.result += formatted
         self.last_recognised_keyword = self.syntax.keyword_name
 

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -14,15 +14,13 @@ from snakefmt.parser.parser import Parser, comment_start
 from snakefmt.parser.syntax import (
     COMMENT_SPACING,
     TAB,
+    InlineSingleParam,
     Parameter,
     ParameterSyntax,
-    RuleInlineSingleParam,
     SingleParam,
     Syntax,
 )
 from snakefmt.types import TokenIterator
-
-rule_like_formatted = {"rule", "checkpoint"}
 
 triple_quote_matcher = re.compile(
     r"^\s*(\w?\"{3}.*?\"{3})|^\s*(\w?'{3}.*?'{3})", re.DOTALL | re.MULTILINE
@@ -223,10 +221,9 @@ class Formatter(Parser):
 
         p_class = parameters.__class__
         single_param = issubclass(p_class, SingleParam)
-        inline_fmting = single_param
-        # Cancel single param formatting if in rule-like context and param not inline
-        if in_rule and p_class is not RuleInlineSingleParam:
-            inline_fmting = False
+        inline_fmting = False
+        if p_class is InlineSingleParam:
+            inline_fmting = True
 
         result = f"{used_indent}{parameters.keyword_name}:"
         if inline_fmting:

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -94,7 +94,7 @@ class Formatter(Parser):
                 formatted = "".join(formatted_lines[:-1])  # Remove the 'pass' line
             else:
                 formatted = self.run_black_format_str(self.buffer, self.target_indent)
-            code_indent = self.context.code_indent
+            code_indent = self.syntax.code_indent
             if code_indent is not None:
                 formatted = textwrap.indent(formatted, f"{TAB * code_indent}")
 
@@ -110,13 +110,13 @@ class Formatter(Parser):
         self.buffer = ""
 
     def process_keyword_context(self, in_global_context: bool):
-        cur_indent = self.context.cur_indent
+        cur_indent = self.syntax.cur_indent
         self.add_newlines(cur_indent, in_global_context=in_global_context)
         formatted = (
-            f"{TAB * cur_indent}{self.context.keyword_name}:{self.context.comment}\n"
+            f"{TAB * cur_indent}{self.syntax.keyword_name}:{self.syntax.comment}\n"
         )
         self.result += formatted
-        self.last_recognised_keyword = self.context.keyword_name
+        self.last_recognised_keyword = self.syntax.keyword_name
 
     def process_keyword_param(
         self, param_context: ParameterSyntax, in_global_context: bool

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -113,7 +113,7 @@ class Formatter(Parser):
         cur_indent = self.syntax.cur_indent
         self.add_newlines(cur_indent, in_global_context=in_global_context)
         formatted = (
-            f"{TAB * cur_indent}{self.syntax.keyword_name}:{self.syntax.comment}\n"
+            f"{TAB * cur_indent}{self.syntax.keyword_line}:{self.syntax.comment}\n"
         )
         self.result += formatted
         self.last_recognised_keyword = self.syntax.keyword_name

--- a/snakefmt/parser/grammar.py
+++ b/snakefmt/parser/grammar.py
@@ -25,34 +25,44 @@ class PythonCode(Vocabulary):
     pass
 
 
+# In common between 'use rule' and 'rule'
+rule_properties = dict(
+    name=Grammar(None, SingleParam),
+    input=Grammar(None, ParamList),
+    output=Grammar(None, ParamList),
+    params=Grammar(None, ParamList),
+    threads=Grammar(None, InlineSingleParam),
+    resources=Grammar(None, ParamList),
+    priority=Grammar(None, InlineSingleParam),
+    version=Grammar(None, SingleParam),
+    log=Grammar(None, ParamList),
+    message=Grammar(None, SingleParam),
+    benchmark=Grammar(None, SingleParam),
+    conda=Grammar(None, SingleParam),
+    singularity=Grammar(None, SingleParam),
+    container=Grammar(None, SingleParam),
+    containerized=Grammar(None, SingleParam),
+    envmodules=Grammar(None, NoKeyParamList),
+    wildcard_constraints=Grammar(None, ParamList),
+    shadow=Grammar(None, SingleParam),
+    group=Grammar(None, SingleParam),
+    cache=Grammar(None, InlineSingleParam),
+)
+
+
+class SnakeUseRule(Vocabulary):
+    spec = rule_properties
+
+
 class SnakeRule(Vocabulary):
     spec = dict(
-        name=Grammar(None, SingleParam),
-        input=Grammar(None, ParamList),
-        output=Grammar(None, ParamList),
-        params=Grammar(None, ParamList),
-        threads=Grammar(None, InlineSingleParam),
-        resources=Grammar(None, ParamList),
-        priority=Grammar(None, InlineSingleParam),
-        version=Grammar(None, SingleParam),
-        log=Grammar(None, ParamList),
-        message=Grammar(None, SingleParam),
-        benchmark=Grammar(None, SingleParam),
-        conda=Grammar(None, SingleParam),
-        singularity=Grammar(None, SingleParam),
-        container=Grammar(None, SingleParam),
-        containerized=Grammar(None, SingleParam),
-        envmodules=Grammar(None, NoKeyParamList),
-        wildcard_constraints=Grammar(None, ParamList),
-        shadow=Grammar(None, SingleParam),
-        group=Grammar(None, SingleParam),
         run=Grammar(PythonCode, KeywordSyntax),
         shell=Grammar(None, SingleParam),
         script=Grammar(None, SingleParam),
         notebook=Grammar(None, SingleParam),
         wrapper=Grammar(None, SingleParam),
         cwl=Grammar(None, SingleParam),
-        cache=Grammar(None, InlineSingleParam),
+        **rule_properties
     )
 
 
@@ -97,4 +107,5 @@ class SnakeGlobal(Vocabulary):
         containerized=Grammar(None, InlineSingleParam),
         scattergather=Grammar(None, ParamList),
         module=Grammar(SnakeModule, KeywordSyntax),
+        use=Grammar(SnakeUseRule, KeywordSyntax),
     )

--- a/snakefmt/parser/grammar.py
+++ b/snakefmt/parser/grammar.py
@@ -1,10 +1,10 @@
 from typing import NamedTuple, Optional, Type, Union
 
 from snakefmt.parser.syntax import (
+    InlineSingleParam,
     KeywordSyntax,
-    NoKeywordParamList,
+    NoKeyParamList,
     ParamList,
-    RuleInlineSingleParam,
     SingleParam,
     Syntax,
     Vocabulary,
@@ -31,9 +31,9 @@ class SnakeRule(Vocabulary):
         input=Grammar(None, ParamList),
         output=Grammar(None, ParamList),
         params=Grammar(None, ParamList),
-        threads=Grammar(None, RuleInlineSingleParam),
+        threads=Grammar(None, InlineSingleParam),
         resources=Grammar(None, ParamList),
-        priority=Grammar(None, RuleInlineSingleParam),
+        priority=Grammar(None, InlineSingleParam),
         version=Grammar(None, SingleParam),
         log=Grammar(None, ParamList),
         message=Grammar(None, SingleParam),
@@ -41,7 +41,8 @@ class SnakeRule(Vocabulary):
         conda=Grammar(None, SingleParam),
         singularity=Grammar(None, SingleParam),
         container=Grammar(None, SingleParam),
-        envmodules=Grammar(None, NoKeywordParamList),
+        containerized=Grammar(None, SingleParam),
+        envmodules=Grammar(None, NoKeyParamList),
         wildcard_constraints=Grammar(None, ParamList),
         shadow=Grammar(None, SingleParam),
         group=Grammar(None, SingleParam),
@@ -51,7 +52,17 @@ class SnakeRule(Vocabulary):
         notebook=Grammar(None, SingleParam),
         wrapper=Grammar(None, SingleParam),
         cwl=Grammar(None, SingleParam),
-        cache=Grammar(None, RuleInlineSingleParam),
+        cache=Grammar(None, InlineSingleParam),
+    )
+
+
+class SnakeModule(Vocabulary):
+    spec = dict(
+        snakefile=Grammar(None, SingleParam),
+        config=Grammar(None, SingleParam),
+        skip_validation=Grammar(None, SingleParam),
+        meta_wrapper=Grammar(None, SingleParam),
+        replace_prefix=Grammar(None, SingleParam),
     )
 
 
@@ -65,23 +76,25 @@ class SnakeSubworkflow(Vocabulary):
 
 class SnakeGlobal(Vocabulary):
     spec = dict(
-        envvars=Grammar(None, NoKeywordParamList),
-        include=Grammar(None, SingleParam),
-        workdir=Grammar(None, SingleParam),
-        configfile=Grammar(None, SingleParam),
-        pepfile=Grammar(None, SingleParam),
-        pepschema=Grammar(None, SingleParam),
-        report=Grammar(None, SingleParam),
-        ruleorder=Grammar(None, SingleParam),
+        envvars=Grammar(None, NoKeyParamList),
+        include=Grammar(None, InlineSingleParam),
+        workdir=Grammar(None, InlineSingleParam),
+        configfile=Grammar(None, InlineSingleParam),
+        pepfile=Grammar(None, InlineSingleParam),
+        pepschema=Grammar(None, InlineSingleParam),
+        report=Grammar(None, InlineSingleParam),
+        ruleorder=Grammar(None, InlineSingleParam),
         rule=Grammar(SnakeRule, KeywordSyntax),
         checkpoint=Grammar(SnakeRule, KeywordSyntax),
         subworkflow=Grammar(SnakeSubworkflow, KeywordSyntax),
-        localrules=Grammar(None, NoKeywordParamList),
+        localrules=Grammar(None, NoKeyParamList),
         onstart=Grammar(PythonCode, KeywordSyntax),
         onsuccess=Grammar(PythonCode, KeywordSyntax),
         onerror=Grammar(PythonCode, KeywordSyntax),
         wildcard_constraints=Grammar(None, ParamList),
+        singularity=Grammar(None, InlineSingleParam),
+        container=Grammar(None, InlineSingleParam),
+        containerized=Grammar(None, InlineSingleParam),
         scattergather=Grammar(None, ParamList),
-        singularity=Grammar(None, SingleParam),
-        container=Grammar(None, SingleParam),
+        module=Grammar(SnakeModule, KeywordSyntax),
     )

--- a/snakefmt/parser/grammar.py
+++ b/snakefmt/parser/grammar.py
@@ -11,14 +11,14 @@ from snakefmt.parser.syntax import (
 )
 
 
-class Grammar(NamedTuple):
+class Context(NamedTuple):
     """
-    Ties together a vocabulary and a context (=syntax reader)
-    When a keyword from `vocab` is recognised, a new grammar is induced
+    Ties together a vocabulary and a syntax.
+    When a keyword from `vocab` is recognised, a new context is induced
     """
 
     vocab: Optional[Union[Type[Vocabulary], Vocabulary]]
-    context: Union[Type[Syntax], Syntax]
+    syntax: Union[Type[Syntax], Syntax]
 
 
 class PythonCode(Vocabulary):
@@ -27,26 +27,26 @@ class PythonCode(Vocabulary):
 
 # In common between 'use rule' and 'rule'
 rule_properties = dict(
-    name=Grammar(None, SingleParam),
-    input=Grammar(None, ParamList),
-    output=Grammar(None, ParamList),
-    params=Grammar(None, ParamList),
-    threads=Grammar(None, InlineSingleParam),
-    resources=Grammar(None, ParamList),
-    priority=Grammar(None, InlineSingleParam),
-    version=Grammar(None, SingleParam),
-    log=Grammar(None, ParamList),
-    message=Grammar(None, SingleParam),
-    benchmark=Grammar(None, SingleParam),
-    conda=Grammar(None, SingleParam),
-    singularity=Grammar(None, SingleParam),
-    container=Grammar(None, SingleParam),
-    containerized=Grammar(None, SingleParam),
-    envmodules=Grammar(None, NoKeyParamList),
-    wildcard_constraints=Grammar(None, ParamList),
-    shadow=Grammar(None, SingleParam),
-    group=Grammar(None, SingleParam),
-    cache=Grammar(None, InlineSingleParam),
+    name=Context(None, SingleParam),
+    input=Context(None, ParamList),
+    output=Context(None, ParamList),
+    params=Context(None, ParamList),
+    threads=Context(None, InlineSingleParam),
+    resources=Context(None, ParamList),
+    priority=Context(None, InlineSingleParam),
+    version=Context(None, SingleParam),
+    log=Context(None, ParamList),
+    message=Context(None, SingleParam),
+    benchmark=Context(None, SingleParam),
+    conda=Context(None, SingleParam),
+    singularity=Context(None, SingleParam),
+    container=Context(None, SingleParam),
+    containerized=Context(None, SingleParam),
+    envmodules=Context(None, NoKeyParamList),
+    wildcard_constraints=Context(None, ParamList),
+    shadow=Context(None, SingleParam),
+    group=Context(None, SingleParam),
+    cache=Context(None, InlineSingleParam),
 )
 
 
@@ -56,56 +56,56 @@ class SnakeUseRule(Vocabulary):
 
 class SnakeRule(Vocabulary):
     spec = dict(
-        run=Grammar(PythonCode, KeywordSyntax),
-        shell=Grammar(None, SingleParam),
-        script=Grammar(None, SingleParam),
-        notebook=Grammar(None, SingleParam),
-        wrapper=Grammar(None, SingleParam),
-        cwl=Grammar(None, SingleParam),
+        run=Context(PythonCode, KeywordSyntax),
+        shell=Context(None, SingleParam),
+        script=Context(None, SingleParam),
+        notebook=Context(None, SingleParam),
+        wrapper=Context(None, SingleParam),
+        cwl=Context(None, SingleParam),
         **rule_properties
     )
 
 
 class SnakeModule(Vocabulary):
     spec = dict(
-        snakefile=Grammar(None, SingleParam),
-        config=Grammar(None, SingleParam),
-        skip_validation=Grammar(None, SingleParam),
-        meta_wrapper=Grammar(None, SingleParam),
-        replace_prefix=Grammar(None, SingleParam),
+        snakefile=Context(None, SingleParam),
+        config=Context(None, SingleParam),
+        skip_validation=Context(None, SingleParam),
+        meta_wrapper=Context(None, SingleParam),
+        replace_prefix=Context(None, SingleParam),
     )
 
 
 class SnakeSubworkflow(Vocabulary):
     spec = dict(
-        snakefile=Grammar(None, SingleParam),
-        workdir=Grammar(None, SingleParam),
-        configfile=Grammar(None, SingleParam),
+        snakefile=Context(None, SingleParam),
+        workdir=Context(None, SingleParam),
+        configfile=Context(None, SingleParam),
     )
 
 
 class SnakeGlobal(Vocabulary):
     spec = dict(
-        envvars=Grammar(None, NoKeyParamList),
-        include=Grammar(None, InlineSingleParam),
-        workdir=Grammar(None, InlineSingleParam),
-        configfile=Grammar(None, InlineSingleParam),
-        pepfile=Grammar(None, InlineSingleParam),
-        pepschema=Grammar(None, InlineSingleParam),
-        report=Grammar(None, InlineSingleParam),
-        ruleorder=Grammar(None, InlineSingleParam),
-        rule=Grammar(SnakeRule, KeywordSyntax),
-        checkpoint=Grammar(SnakeRule, KeywordSyntax),
-        subworkflow=Grammar(SnakeSubworkflow, KeywordSyntax),
-        localrules=Grammar(None, NoKeyParamList),
-        onstart=Grammar(PythonCode, KeywordSyntax),
-        onsuccess=Grammar(PythonCode, KeywordSyntax),
-        onerror=Grammar(PythonCode, KeywordSyntax),
-        wildcard_constraints=Grammar(None, ParamList),
-        singularity=Grammar(None, InlineSingleParam),
-        container=Grammar(None, InlineSingleParam),
-        containerized=Grammar(None, InlineSingleParam),
-        scattergather=Grammar(None, ParamList),
-        module=Grammar(SnakeModule, KeywordSyntax),
-        use=Grammar(SnakeUseRule, KeywordSyntax),
+        envvars=Context(None, NoKeyParamList),
+        include=Context(None, InlineSingleParam),
+        workdir=Context(None, InlineSingleParam),
+        configfile=Context(None, InlineSingleParam),
+        pepfile=Context(None, InlineSingleParam),
+        pepschema=Context(None, InlineSingleParam),
+        report=Context(None, InlineSingleParam),
+        ruleorder=Context(None, InlineSingleParam),
+        rule=Context(SnakeRule, KeywordSyntax),
+        checkpoint=Context(SnakeRule, KeywordSyntax),
+        subworkflow=Context(SnakeSubworkflow, KeywordSyntax),
+        localrules=Context(None, NoKeyParamList),
+        onstart=Context(PythonCode, KeywordSyntax),
+        onsuccess=Context(PythonCode, KeywordSyntax),
+        onerror=Context(PythonCode, KeywordSyntax),
+        wildcard_constraints=Context(None, ParamList),
+        singularity=Context(None, InlineSingleParam),
+        container=Context(None, InlineSingleParam),
+        containerized=Context(None, InlineSingleParam),
+        scattergather=Context(None, ParamList),
+        module=Context(SnakeModule, KeywordSyntax),
+        use=Context(SnakeUseRule, KeywordSyntax),
     )

--- a/snakefmt/parser/parser.py
+++ b/snakefmt/parser/parser.py
@@ -152,24 +152,24 @@ class Parser(ABC):
         accepts_py = new_context.vocab is PythonCode
         if issubclass(new_context.syntax, KeywordSyntax):
             in_global_context = self.in_global_context
-            new_syntax = new_context.syntax(
-                keyword,
-                self.syntax.cur_indent + 1,
-                snakefile=self.snakefile,
-                incident_syntax=self.syntax,
-                from_python=from_python,
-                accepts_py=accepts_py,
-            )
+            saved_context = self.context
             # 'use' keyword can not enter a new context
-            if new_syntax.enter_context:
-                self.context = Context(
-                    new_context.vocab(),
-                    new_syntax,
-                )
+            self.context = Context(
+                new_context.vocab(),
+                new_context.syntax(
+                    keyword,
+                    self.syntax.cur_indent + 1,
+                    snakefile=self.snakefile,
+                    incident_syntax=self.syntax,
+                    from_python=from_python,
+                    accepts_py=accepts_py,
+                ),
+            )
+            self.process_keyword_context(in_global_context)
+            if self.syntax.enter_context:
                 self.context_stack.append(self.context)
-                self.process_keyword_context(in_global_context)
             else:
-                self.result += new_syntax.keyword_line
+                self.context = saved_context
 
             status = self.syntax.get_next_queriable(self.snakefile)
             self.buffer += status.buffer

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -164,7 +164,7 @@ class KeywordSyntax(Syntax):
         keyword_name: str,
         target_indent: int,
         snakefile: TokenIterator = None,
-        incident_context: "KeywordSyntax" = None,
+        incident_syntax: "KeywordSyntax" = None,
         from_python: bool = False,
         accepts_py: bool = False,
     ):
@@ -174,7 +174,7 @@ class KeywordSyntax(Syntax):
         self.queriable = True
         self.from_python = from_python
 
-        if incident_context is not None:
+        if incident_syntax is not None:
             if self.token.type != tokenize.NEWLINE:
                 raise SyntaxError(
                     (
@@ -183,7 +183,7 @@ class KeywordSyntax(Syntax):
                     )
                 )
             if not from_python:
-                incident_context.add_processed_keyword(self.token, self.keyword_name)
+                incident_syntax.add_processed_keyword(self.token, self.keyword_name)
 
     def add_processed_keyword(self, token: Token, keyword: str, check_dup: bool = True):
         if check_dup and keyword in self.processed_keywords:

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -24,7 +24,7 @@ from snakefmt.types import (
     not_empty,
 )
 
-possibly_named_keywords = {"rule", "checkpoint", "subworkflow"}
+possibly_named_keywords = {"rule", "checkpoint", "subworkflow", "module"}
 
 # ___Token parsing___#
 QUOTES = {'"', "'"}
@@ -396,12 +396,12 @@ class SingleParam(ParameterSyntax):
 ParamList = ParameterSyntax
 
 
-class RuleInlineSingleParam(SingleParam):
+class InlineSingleParam(SingleParam):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
-class NoKeywordParamList(ParameterSyntax):
+class NoKeyParamList(ParameterSyntax):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -97,6 +97,31 @@ class TestSimpleParamFormatting:
         assert actual == expected
 
 
+class TestModuleFormatting:
+    def test_module_specific_keyword_formatting(self):
+        formatter = setup_formatter(
+            "module a: \n"
+            f'{TAB * 1}snakefile: "other.smk"\n'
+            f"{TAB * 1}config: config\n"
+            f'{TAB * 1}replace_prefix: {{"results/": "results/testmodule/"}}\n'
+            f'{TAB * 1}meta_wrapper: "0.72.0/meta/bio/bwa_mapping"\n'
+        )
+
+        expected = (
+            "module a:\n"
+            f"{TAB * 1}snakefile:\n"
+            f'{TAB * 2}"other.smk"\n'
+            f"{TAB * 1}config:\n"
+            f"{TAB * 2}config\n"
+            f"{TAB * 1}replace_prefix:\n"
+            f'{TAB * 2}{{"results/": "results/testmodule/"}}\n'
+            f"{TAB * 1}meta_wrapper:\n"
+            f'{TAB * 2}"0.72.0/meta/bio/bwa_mapping"\n'
+        )
+
+        assert formatter.get_formatted() == expected
+
+
 class TestComplexParamFormatting:
     """
     Parameters are delimited with ','

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -738,7 +738,7 @@ class TestNewlineSpacing:
         global_single_param_keywords = [
             keyval[0]
             for keyval in SnakeGlobal.spec.items()
-            if keyval[1].context is SingleParam
+            if keyval[1].syntax is SingleParam
         ]
         snakecode = '{keyword_param}: "value1"\n{keyword_param}: "value2"\n'
         for keyword in global_single_param_keywords:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -122,6 +122,23 @@ class TestModuleFormatting:
         assert formatter.get_formatted() == expected
 
 
+class TestUseRuleFormatting:
+    def test_use_rule_rule_like_indented(self):
+        snakecode = (
+            'include: "file.txt"\n\n\n'
+            "use rule a from module with:\n"
+            f"{TAB * 1}input:\n"
+            f"{TAB * 2}b=2,\n"
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
+
+    def test_use_rule_no_with_two_line_indented(self):
+        snakecode = 'include: "file.txt"\n\n\n' "use rule * from module as module_*\n"
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
+
+
 class TestComplexParamFormatting:
     """
     Parameters are delimited with ','
@@ -905,7 +922,6 @@ class TestLineWrapping:
         formatter = setup_formatter(snakecode, line_length)
 
         actual = formatter.get_formatted()
-        print(actual)
         expected = (
             f"rule coverage_report:\n"
             f"{TAB * 1}input:\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -138,6 +138,14 @@ class TestUseRuleFormatting:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
+    def test_use_rule_with_comment(self):
+        snakecode = (
+            "# Comment here\n\n\n"
+            "use rule * from module as module_*  # Use these cool rules\n"
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
+
 
 class TestComplexParamFormatting:
     """

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -25,6 +25,11 @@ class TestCompleteness:
         existing_keywords = set(grammar.SnakeGlobal.spec)
         self.check_completeness(target_keywords, existing_keywords)
 
+    def test_module_context_completeness(self):
+        target_keywords = set(parser.Module.subautomata)
+        existing_keywords = set(grammar.SnakeModule.spec)
+        self.check_completeness(target_keywords, existing_keywords)
+
     def test_subworkflow_context_completeness(self):
         target_keywords = set(parser.Subworkflow.subautomata)
         existing_keywords = set(grammar.SnakeSubworkflow.spec)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -35,6 +35,11 @@ class TestCompleteness:
         existing_keywords = set(grammar.SnakeSubworkflow.spec)
         self.check_completeness(target_keywords, existing_keywords)
 
+    def test_use_rule_context_completeness(self):
+        target_keywords = set(parser.UseRule.subautomata)
+        existing_keywords = set(grammar.SnakeUseRule.spec)
+        self.check_completeness(target_keywords, existing_keywords)
+
     def test_rule_context_completeness(self):
         target_keywords = set(parser.Rule.subautomata)
         existing_keywords = set(grammar.SnakeRule.spec)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,6 @@ from snakefmt.exceptions import (
     InvalidParameter,
     InvalidParameterSyntax,
     InvalidPython,
-    NamedKeywordError,
     NoParametersError,
     TooManyParameters,
 )
@@ -70,7 +69,7 @@ class TestKeywordSyntax:
             Formatter(snakefile)
 
     def test_invalid_name_for_keyword(self):
-        with pytest.raises(NamedKeywordError, match="Invalid name.*checkpoint"):
+        with pytest.raises(SyntaxError, match=".*checkpoint.*valid identifier"):
             stream = StringIO("checkpoint (): \n" '\tinput: "a"')
             snakefile = Snakefile(stream)
             Formatter(snakefile)
@@ -129,9 +128,9 @@ class TestUseRuleKeywordSyntax:
         setup_formatter("use rule * from mymodule as mymodule_*")
 
     def test_modified_rule_from_module_passes(self):
-        setup_formatter("use rule a from mymodule with:" f"{TAB * 1}threads: 4")
+        setup_formatter("use rule a from mymodule with:\n" f"{TAB * 1}threads: 4")
         setup_formatter(
-            "use rule b from mymodule as my_b with:"
+            "use rule b from mymodule as my_b with:\n"
             f"{TAB * 1}output:\n"
             f'{TAB * 2}"new_output"'
         )
@@ -139,7 +138,7 @@ class TestUseRuleKeywordSyntax:
     def test_use_rule_cannot_use_rule_specific_keywords(self):
         with pytest.raises(SyntaxError, match="Unrecognised keyword"):
             setup_formatter(
-                "use rule a from mymodule with:" f'{TAB * 1}shell: "mycommand"'
+                "use rule a from mymodule with:\n" f'{TAB * 1}shell: "mycommand"'
             )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -120,6 +120,29 @@ class TestKeywordSyntax:
             Formatter(snakefile)
 
 
+class TestUseRuleKeywordSyntax:
+    def test_rule_from_module_passes(self):
+        setup_formatter("use rule a from mymodule")
+
+    def test_renamed_rule_from_module_passes(self):
+        setup_formatter("use rule a from mymodule as mymodule_a")
+        setup_formatter("use rule * from mymodule as mymodule_*")
+
+    def test_modified_rule_from_module_passes(self):
+        setup_formatter("use rule a from mymodule with:" f"{TAB * 1}threads: 4")
+        setup_formatter(
+            "use rule b from mymodule as my_b with:"
+            f"{TAB * 1}output:\n"
+            f'{TAB * 2}"new_output"'
+        )
+
+    def test_use_rule_cannot_use_rule_specific_keywords(self):
+        with pytest.raises(SyntaxError, match="Unrecognised keyword"):
+            setup_formatter(
+                "use rule a from mymodule with:" f'{TAB * 1}shell: "mycommand"'
+            )
+
+
 class TestParamSyntax:
     def test_key_value_no_key_fails(self):
         with pytest.raises(InvalidParameterSyntax, match="Operator ="):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -123,6 +123,9 @@ class TestUseRuleKeywordSyntax:
     def test_rule_from_module_passes(self):
         setup_formatter("use rule a from mymodule")
 
+    def test_rule_modified_from_rule_passes(self):
+        setup_formatter("use rule a as b with:\n" f"{TAB * 1}threads: 4")
+
     def test_renamed_rule_from_module_passes(self):
         setup_formatter("use rule a from mymodule as mymodule_a")
         setup_formatter("use rule * from mymodule as mymodule_*")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -138,6 +138,13 @@ class TestUseRuleKeywordSyntax:
             f'{TAB * 2}"new_output"'
         )
 
+    def test_invalid_syntax_throws(self):
+        with pytest.raises(SyntaxError, match="not of form"):
+            setup_formatter("use rule b from *")
+
+        with pytest.raises(SyntaxError, match="not of form"):
+            setup_formatter("use rule b from module as with:")
+
     def test_use_rule_cannot_use_rule_specific_keywords(self):
         with pytest.raises(SyntaxError, match="Unrecognised keyword"):
             setup_formatter(


### PR DESCRIPTION
This PR addresses #99 by introducing support for the new module syntax.

### Added

* Support for module syntax: `module` keyword and `use rule` syntax (#99)
* Support for `containerized` keyword

### Changed

* Updated snakemake dependency to ^6.0.0 (#99)

@mbhall88 I think this would be a change up to version 0.4.0 ? I haven't done that yet, wanted to review the code here first.