### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## [0.4.1]
+
+### Fixed
+
+* Add support for multiple anonymous rules, as per [snakemake grammar][snakemake_grammar] ([#103][103])
+* Newline bug in `use` syntax ([#106][106])
+
 ## [0.4.0]
 
 ### Added
@@ -147,7 +154,9 @@ is 40 character long, the line is 48 characters long. However, we were only pass
 
 - First release - so everything you see is new!
 
+[snakemake_grammar]: https://snakemake.readthedocs.io/en/stable/snakefiles/writing_snakefiles.html#grammar
 [unreleased]: https://github.com/snakemake/snakefmt/compare/0.4.0...HEAD
+[0.4.1]: https://github.com/snakemake/snakefmt/releases/tag/0.4.1
 [0.4.0]: https://github.com/snakemake/snakefmt/releases/tag/0.4.0
 [0.3.1]: https://github.com/snakemake/snakefmt/releases/tag/0.3.1
 [0.3.0]: https://github.com/snakemake/snakefmt/releases/tag/0.3.0
@@ -183,4 +192,4 @@ is 40 character long, the line is 48 characters long. However, we were only pass
 [96]: https://github.com/snakemake/snakefmt/issues/96
 [97]: https://github.com/snakemake/snakefmt/pull/97
 [99]: https://github.com/snakemake/snakefmt/issues/99
-
+[106]: https://github.com/snakemake/snakefmt/issues/106

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakefmt"
-version = "0.4.0"
+version = "0.4.1"
 description = "The uncompromising Snakemake code formatter"
 authors = ["Michael Hall <michael@mbh.sh>", "Brice Letcher <bletcher@ebi.ac.uk>"]
 license = "MIT"

--- a/snakefmt/parser/parser.py
+++ b/snakefmt/parser/parser.py
@@ -172,7 +172,8 @@ class Parser(ABC):
                 self.context = saved_context
 
             status = self.syntax.get_next_queriable(self.snakefile)
-            self.buffer += status.buffer
+            # lstrip forces the formatter deal with newlines
+            self.buffer += status.buffer.lstrip()
             return status
 
         elif issubclass(new_context.syntax, ParameterSyntax):

--- a/snakefmt/parser/syntax.py
+++ b/snakefmt/parser/syntax.py
@@ -224,7 +224,8 @@ class KeywordSyntax(Syntax):
             raise DuplicateKeyWordError(
                 f"L{token.start[0]}: '{keyword}' specified twice."
             )
-        self.processed_keywords.add(keyword)
+        if keyword != "rule":  # Allows anonymous rules
+            self.processed_keywords.add(keyword)
 
     def check_empty(self):
         if len(self.processed_keywords) == 0:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -146,6 +146,15 @@ class TestUseRuleFormatting:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
+    def test_use_rule_newline_spacing(self):
+        snakecode = (
+            "use rule * from module as module_*\n\n\n"
+            "rule baz:\n"
+            f"{TAB * 1}threads: 4\n"
+        )
+        formatter = setup_formatter(snakecode)
+        assert formatter.get_formatted() == snakecode
+
 
 class TestComplexParamFormatting:
     """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -52,33 +52,23 @@ class TestSnakefileTokenizer:
 class TestKeywordSyntax:
     def test_nocolon(self):
         with pytest.raises(SyntaxError, match="Colon.*expected"):
-            stream = StringIO("rule a")
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("rule a")
 
     def test_no_newline_in_keyword_context_SMK_NOBREAK(self):
         with pytest.raises(SyntaxError, match="Newline expected"):
-            stream = StringIO('rule a: input: "input_file"')
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter('rule a: input: "input_file"')
 
     def test_keyword_cannot_be_named(self):
         with pytest.raises(SyntaxError, match="Colon.*expected"):
-            stream = StringIO('workdir a: "/to/dir"')
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter('workdir a: "/to/dir"')
 
     def test_invalid_name_for_keyword(self):
         with pytest.raises(SyntaxError, match=".*checkpoint.*valid identifier"):
-            stream = StringIO("checkpoint (): \n" '\tinput: "a"')
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("checkpoint (): \n" '\tinput: "a"')
 
     def test_explicitly_unrecognised_keyword(self):
         with pytest.raises(SyntaxError, match="Unrecognised keyword"):
-            stream = StringIO("rule a:" "\n\talien_keyword: 3")
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("rule a:" "\n\talien_keyword: 3")
 
     def test_implicitly_unrecognised_keyword(self):
         """
@@ -87,36 +77,31 @@ class TestKeywordSyntax:
         In that case black will complain of invalid python and not format it.
         """
         with pytest.raises(InvalidPython):
-            stream = StringIO(f"role a: \n" f'{TAB * 1}input: "b"')
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter(f"role a: \n" f'{TAB * 1}input: "b"')
 
     def test_duplicate_rule_fails_SMK_NOBREAK(self):
         with pytest.raises(DuplicateKeyWordError, match="rule a"):
-            stream = StringIO("rule a:\n" '\tinput: "a"\n' "rule a:\n" '\tinput:"b"')
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("rule a:\n" '\tinput: "a"\n' "rule a:\n" '\tinput:"b"')
+
+    def test_duplicate_anonymous_rule_passes(self):
+        setup_formatter(
+            "rule:\n" f"{TAB * 1}threads: 4\n" "rule:\n" f"{TAB * 1}threads: 4\n"
+        )
 
     def test_authorised_duplicate_keyword_passes(self):
         setup_formatter('include: "a"\n' 'include: "b"\n')
 
     def test_empty_keyword_SMK_NOBREAK(self):
         with pytest.raises(EmptyContextError, match="rule"):
-            stream = StringIO("rule a:")
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("rule a:")
 
     def test_empty_keyword_2(self):
         with pytest.raises(NoParametersError, match="threads"):
-            stream = StringIO("rule a:" "\n\tthreads:")
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("rule a:" "\n\tthreads:")
 
     def test_empty_keyword_3(self):
         with pytest.raises(NoParametersError, match="message"):
-            stream = StringIO("rule a:" "\n\tthreads: 3" "\n\tmessage:")
-            snakefile = Snakefile(stream)
-            Formatter(snakefile)
+            setup_formatter("rule a:" "\n\tthreads: 3" "\n\tmessage:")
 
 
 class TestUseRuleKeywordSyntax:


### PR DESCRIPTION
Fixes two bugs (see below).

One point for discussion is it does not fix #104 and #105 whereby empty `input:` is not allowed by us; i don't think it's technically allowed by snakemake grammar either, but is allowed in practice. Not sure what to do there.

### Fixed

* Add support for multiple anonymous rules, as per [snakemake grammar](https://snakemake.readthedocs.io/en/stable/snakefiles/writing_snakefiles.html#grammar) (#103)
* Newline bug in `use` syntax (#106)
