### PR TITLE
docs: update pre commit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ To do so, create the file `.pre-commit-config.yaml` in the root of your project 
 ```yaml
 repos:
   - repo: https://github.com/snakemake/snakefmt
-    rev: 0.5.0 # Replace by any tag/version ≥0.2.4 : https://github.com/snakemake/snakefmt/releases
+    rev: v0.10.2 # Replace by any tag/version ≥v0.6 : https://github.com/snakemake/snakefmt/releases
     hooks:
       - id: snakefmt
 ```

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ To do so, create the file `.pre-commit-config.yaml` in the root of your project 
 ```yaml
 repos:
   - repo: https://github.com/snakemake/snakefmt
-    rev: v0.10.2 # Replace by any tag/version ≥v0.6 : https://github.com/snakemake/snakefmt/releases
+    rev: v0.10.2 # Replace by any tag/version ≥v0.6.0 : https://github.com/snakemake/snakefmt/releases
     hooks:
       - id: snakefmt
 ```


### PR DESCRIPTION
Hi,

I realised that from your release `0.5.0` to `0.6.0` the labels switched from `0.5.0` to `v0.6.0`.
Therefore, the example pre-commit snippet in the README is still correct, but once somebody wants to go beyond by just updating the number (as I did) they will get an error from pre-commit.
 
I think it would be nice to update this small section. Here is a suggestion for the fix with the newest `snakefmt` version.