### PR TITLE
docs: added emacs to editor integration docs

### DIFF
--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -12,7 +12,7 @@ already.**
 - [PyCharm/JetBrains IDEA](#pycharmjetbrains-idea)
 - [Visual Studio Code](#visual-studio-code)
 - [Vim](#Vim)
-- [Emacs](#Emacs)
+- [emacs](#emacs)
 
 
 ## PyCharm/JetBrains IDEA
@@ -109,14 +109,13 @@ Credit: plugin inspired by
 
 Under certain circumstances, import errors can occur when using a virtual environment due to _Black_ dependency imports. See the [_Black_ Vim integration docs](https://black.readthedocs.io/en/stable/editor_integration.html#vim) for more details and a potential solution.
 
-## Emacs
+## emacs
 
 The [`format-all` package](https://github.com/lassik/emacs-format-all-the-code) supports use of `snakefmt` out of the box provided `snakefmt` is available on the `exec-path`; it should suffice to have `snakefmt` available on your `PATH`.
 
-`snakefmt` can be invoked in a buffer using `format-all` in the usual way with `format-all-buffer`, and also upon saving with the addition of a hook to your dotfile:
+`snakefmt` can be invoked in a buffer using `format-all` in the usual way with `format-all-buffer`, and also by adding a hook to your dotfile to enable the `format-all-mode` minor mode. If you are using [`snakemake-mode`](https://git.kyleam.com/snakemake-mode/about/) already, you can do this with:
+```elisp
+(add-hook `snakemake-mode-hook #`format-all-mode)
 ```
-(add-hook 'prog-mode-hook 'format-all-mode)
-```
-Note that this hook will run the relevant formatter on files containing *any* programming language for which a formatter is available to `format-all`.
 
 See the [`format-all` repo](https://github.com/lassik/emacs-format-all-the-code) for more documentation.

--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -12,6 +12,7 @@ already.**
 - [PyCharm/JetBrains IDEA](#pycharmjetbrains-idea)
 - [Visual Studio Code](#visual-studio-code)
 - [Vim](#Vim)
+- [Emacs](#Emacs)
 
 
 ## PyCharm/JetBrains IDEA
@@ -107,3 +108,15 @@ Credit: plugin inspired by
 ### Troubleshooting
 
 Under certain circumstances, import errors can occur when using a virtual environment due to _Black_ dependency imports. See the [_Black_ Vim integration docs](https://black.readthedocs.io/en/stable/editor_integration.html#vim) for more details and a potential solution.
+
+## Emacs
+
+The [`format-all` package](https://github.com/lassik/emacs-format-all-the-code) supports use of `snakefmt` out of the box provided `snakefmt` is available on the `exec-path`; it should suffice to have `snakefmt` available on your `PATH`.
+
+`snakefmt` can be invoked in a buffer using `format-all` in the usual way with `format-all-buffer`, and also upon saving with the addition of a hook to your dotfile:
+```
+(add-hook 'prog-mode-hook 'format-all-mode)
+```
+Note that this hook will run the relevant formatter on files containing *any* programming language for which a formatter is available to `format-all`.
+
+See the [`format-all` repo](https://github.com/lassik/emacs-format-all-the-code) for more documentation.


### PR DESCRIPTION
I'm not sure how long `format-all` has supported `snakefmt`, but I thought it would be helpful to note that here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions for integrating with Emacs using the `format-all` package, including setup steps and links to related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->