### PR TITLE
chore(tomllib): change toml to tomllib

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ "3.11", "3.12", "3.13" ]
         os: [ ubuntu-latest, macos-latest ]
 
     steps:

--- a/snakefmt/config.py
+++ b/snakefmt/config.py
@@ -2,13 +2,13 @@
 Code for searching for and parsing snakefmt configuration files
 """
 
+import tomllib
 from dataclasses import fields
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 import click
-import toml
 from black import Mode
 
 from snakefmt import DEFAULT_LINE_LENGTH, DEFAULT_TARGET_VERSIONS
@@ -79,11 +79,12 @@ def read_snakefmt_config(path: Optional[str]) -> Dict[str, str]:
     if path is None:
         return dict()
     try:
-        config_toml = toml.load(path)
+        with open(path, "rb") as f:
+            config_toml = tomllib.load(f)
         config = config_toml.get("tool", {}).get("snakefmt", {})
         config = {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
         return config
-    except (toml.TomlDecodeError, OSError) as error:
+    except (tomllib.TOMLDecodeError, OSError) as error:
         raise click.FileError(
             filename=path, hint=f"Error reading configuration file: {error}"
         )
@@ -118,9 +119,10 @@ def read_black_config(path: Optional[PathLike]) -> Mode:
         raise FileNotFoundError(f"{path} is not a file.")
 
     try:
-        pyproject_toml = toml.load(path)
+        with open(path, "rb") as f:
+            pyproject_toml = tomllib.load(f)
         config = pyproject_toml.get("tool", {}).get("black", {})
-    except toml.TomlDecodeError as error:
+    except tomllib.TOMLDecodeError as error:
         raise MalformattedToml(error)
 
     valid_black_filemode_params = sorted([field.name for field in fields(Mode)])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 pytest_plugins = "pytester"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest import mock
 
 import black
+import black.const
 import click
 import pytest
 
@@ -19,7 +20,7 @@ from tests import setup_formatter
 
 
 def test_black_and_snakefmt_default_line_lengths_aligned():
-    assert DEFAULT_LINE_LENGTH == black.DEFAULT_LINE_LENGTH
+    assert DEFAULT_LINE_LENGTH == black.const.DEFAULT_LINE_LENGTH
 
 
 class TestFindPyprojectToml:
@@ -49,23 +50,24 @@ class TestConfigAdherence:
         actual = cli_runner.invoke(main, params, input=stdin)
         assert actual.exit_code == 0
 
-        expected_output = """include: \"a\"
-
-
-list_of_lots_of_things = [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-]
-"""
-        assert actual.output == expected_output
+        expected_output = (
+            'include: "a"\n'
+            "\n"
+            "\n"
+            "list_of_lots_of_things = [\n"
+            "    1,\n"
+            "    2,\n"
+            "    3,\n"
+            "    4,\n"
+            "    5,\n"
+            "    6,\n"
+            "    7,\n"
+            "    8,\n"
+            "    9,\n"
+            "    10,\n"
+            "]\n"
+        )
+        assert actual.stdout == expected_output
 
     def test_config_adherence_for_code_inside_rules(self, cli_runner, tmp_path):
         stdin = (
@@ -82,9 +84,9 @@ list_of_lots_of_things = [
 
             assert actual.exit_code == 0
             if expect_same:
-                assert actual.output == stdin
+                assert actual.stdout == stdin
             else:
-                assert actual.output != stdin
+                assert actual.stdout != stdin
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:
@@ -254,7 +256,7 @@ class TestReadBlackConfig:
         with pytest.raises(MalformattedToml) as error:
             read_black_config(path)
 
-        assert error.match("invalid character")
+        assert error.match("Invalid statement")
 
     def test_skip_string_normalisation_handled_with_snakecase(self, tmp_path):
         formatter = setup_formatter("")

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -6,7 +6,7 @@ from typing import Optional
 from unittest import mock
 
 import pytest
-from black import get_gitignore
+from black.files import get_gitignore
 
 from snakefmt.diff import ExitCode
 from snakefmt.formatter import TAB
@@ -15,8 +15,7 @@ from snakefmt.snakefmt import construct_regex, get_snakefiles_in_dir, main
 
 class TestCLIBasic:
     def test_noArgsPassed_printsNothingToDo(self, cli_runner):
-        params = []
-        actual = cli_runner.invoke(main, params)
+        actual = cli_runner.invoke(main, [])
         assert actual.exit_code == 0
         assert "Nothing to do" in actual.stderr
 
@@ -51,7 +50,7 @@ class TestCLIBasic:
 
         expected_output = f'rule all:\n{TAB}input:\n{TAB*2}"c",\n'
 
-        assert actual.output == expected_output
+        assert actual.stdout == expected_output
 
     def test_src_dir_arg_files_modified_inplace(self, cli_runner):
         with tempfile.TemporaryDirectory(dir=".") as tmpdir:
@@ -186,7 +185,7 @@ class TestCLICheck:
 
         assert ExitCode(result.exit_code) is ExitCode.WOULD_CHANGE
         expected_output = "=====> Diff for stdin <=====\n\n- x='foo'\n+ x = \"foo\"\n\n"
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_check_and_diff_doesnt_output_diff_if_error(self, cli_runner):
         stdin = "rule:rule:\n"
@@ -195,7 +194,7 @@ class TestCLICheck:
         result = cli_runner.invoke(main, params, input=stdin)
 
         assert ExitCode(result.exit_code) is ExitCode.ERROR
-        assert result.output == ""
+        assert result.stdout == ""
 
 
 class TestCLIDiff:
@@ -217,7 +216,7 @@ class TestCLIDiff:
             "?          ^ ^\n\n"
         )
 
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_compact_diff_works_as_expected(self, cli_runner):
         stdin = "include: 'a'\n"
@@ -238,7 +237,7 @@ class TestCLIDiff:
             '+include: "a"\n\n'
         )
 
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_compact_diff_and_diff_given_runs_compact_diff(self, cli_runner):
         stdin = "include: 'a'\n"
@@ -259,7 +258,7 @@ class TestCLIDiff:
             '+include: "a"\n\n'
         )
 
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_diff_does_not_format_file(self, cli_runner, tmp_path):
         content = "include: 'a'\nlist_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8]"
@@ -284,7 +283,7 @@ class TestCLIDiff:
 
         assert isinstance(result.exception, SyntaxError)
         assert result.exit_code != 0
-        assert result.output == ""
+        assert result.stdout == ""
 
 
 class TestConstructRegex:
@@ -363,13 +362,13 @@ class TestCLIValidRegex:
                 with (abs_tmpdir / ".gitignore").open("w") as fout:
                     fout.write(gitignored)
                 gitignore = get_gitignore(abs_tmpdir)
-            snakefiles = get_snakefiles_in_dir(
+            smks = get_snakefiles_in_dir(
                 path=abs_tmpdir,
                 include=include,
                 exclude=exclude,
                 gitignore=gitignore,
             )
-            snakefiles = list(map(lambda p: str(p.relative_to(abs_tmpdir)), snakefiles))
+            snakefiles = list(map(lambda p: str(p.relative_to(abs_tmpdir)), smks))
         return Counter(snakefiles)
 
     @mock.patch("pathspec.PathSpec")
@@ -379,8 +378,7 @@ class TestCLIValidRegex:
         exclude = re.compile(r".*")
 
         actual = self.find_files_to_format(include, exclude, mock_gitignore)
-        expected = Counter()
-        assert actual == expected
+        assert actual == Counter()
 
     @mock.patch("pathspec.PathSpec")
     def test_includeAllFiles_returnAll(self, mock_gitignore: mock.MagicMock):


### PR DESCRIPTION
this PR will close #255 as it follow the suggestion.

It is really annoying when I cannot format the snakefiles in snakemake main reposity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Python 3.13.

* **Refactor**
  * Improved TOML configuration parsing with clearer error messages for malformed files.

* **Chores**
  * Updated supported Python versions: dropped 3.9 and 3.10; now testing and supporting 3.11, 3.12, and 3.13.

* **Tests**
  * Adjusted test suite to align with updated CLI output and parsing behavior; no changes to the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->