### PR TITLE
fix: edge cases when snakefmt break snakefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ "3.11", "3.12", "3.13" ]
         os: [ ubuntu-latest, macos-latest ]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ snakefmt = 'snakefmt.snakefmt:main'
 python = "^3.11"
 click = "^8.0.0"
 black = "^24.3.0"
-toml = "^0.10.2"
-importlib_metadata = {version = ">=1.7.0,<5.0", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"

--- a/snakefmt/__init__.py
+++ b/snakefmt/__init__.py
@@ -6,9 +6,9 @@ importlib fetches version from distribution metadata files
 (in dist-info or egg-info dirs).
 From Python 3.8, importlib_metadata is in standard library as importlib.metadata.
 """
-from black.mode import TargetVersion
-
 from importlib import metadata
+
+from black.mode import TargetVersion
 
 __version__ = metadata.version("snakefmt")
 

--- a/snakefmt/__init__.py
+++ b/snakefmt/__init__.py
@@ -6,12 +6,9 @@ importlib fetches version from distribution metadata files
 (in dist-info or egg-info dirs).
 From Python 3.8, importlib_metadata is in standard library as importlib.metadata.
 """
-from black import TargetVersion
+from black.mode import TargetVersion
 
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
+from importlib import metadata
 
 __version__ = metadata.version("snakefmt")
 
@@ -20,9 +17,7 @@ fstring_tokeniser_in_use = sys.version_info >= (3, 12)
 
 DEFAULT_LINE_LENGTH = 88
 DEFAULT_TARGET_VERSIONS = {
-    TargetVersion.PY38,
-    TargetVersion.PY39,
-    TargetVersion.PY310,
     TargetVersion.PY311,
     TargetVersion.PY312,
+    TargetVersion.PY313,
 }

--- a/snakefmt/config.py
+++ b/snakefmt/config.py
@@ -2,13 +2,13 @@
 Code for searching for and parsing snakefmt configuration files
 """
 
+import tomllib
 from dataclasses import fields
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 import click
-import toml
 from black import Mode
 
 from snakefmt import DEFAULT_LINE_LENGTH, DEFAULT_TARGET_VERSIONS
@@ -79,11 +79,12 @@ def read_snakefmt_config(path: Optional[str]) -> Dict[str, str]:
     if path is None:
         return dict()
     try:
-        config_toml = toml.load(path)
+        with open(path, "rb") as f:
+            config_toml = tomllib.load(f)
         config = config_toml.get("tool", {}).get("snakefmt", {})
         config = {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
         return config
-    except (toml.TomlDecodeError, OSError) as error:
+    except (tomllib.TOMLDecodeError, OSError) as error:
         raise click.FileError(
             filename=path, hint=f"Error reading configuration file: {error}"
         )
@@ -118,9 +119,10 @@ def read_black_config(path: Optional[PathLike]) -> Mode:
         raise FileNotFoundError(f"{path} is not a file.")
 
     try:
-        pyproject_toml = toml.load(path)
+        with open(path, "rb") as f:
+            pyproject_toml = tomllib.load(f)
         config = pyproject_toml.get("tool", {}).get("black", {})
-    except toml.TomlDecodeError as error:
+    except tomllib.TOMLDecodeError as error:
         raise MalformattedToml(error)
 
     valid_black_filemode_params = sorted([field.name for field in fields(Mode)])

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -4,12 +4,12 @@ from ast import parse as ast_parse
 from copy import copy
 from typing import Optional
 
-import black
+import black.parsing
 
 from snakefmt.config import PathLike, read_black_config
 from snakefmt.exceptions import InvalidParameterSyntax, InvalidPython
 from snakefmt.logging import Warnings
-from snakefmt.parser.parser import Parser, comment_start
+from snakefmt.parser.parser import Parser, Snakefile, comment_start
 from snakefmt.parser.syntax import (
     COMMENT_SPACING,
     InlineSingleParam,
@@ -18,14 +18,11 @@ from snakefmt.parser.syntax import (
     ParamList,
     SingleParam,
     Syntax,
+    split_code_string,
 )
-from snakefmt.types import TAB, TokenIterator
+from snakefmt.types import TAB
 
 TAB_SIZE = len(TAB)
-# This regex matches any number of consecutive strings; each can span multiple lines.
-full_string_matcher = re.compile(
-    r"^\s*(\w?([\"']{3}.*?[\"']{3})|([\"']{1}.*?[\"']{1}))$", re.DOTALL | re.MULTILINE
-)
 # this regex matches any docstring; can span multiple lines
 docstring_matcher = re.compile(
     r"\s*([rR]?[\"']{3}.*?[\"']{3})", re.DOTALL | re.MULTILINE
@@ -59,7 +56,7 @@ def index_of_first_docstring(s: str) -> Optional[int]:
 class Formatter(Parser):
     def __init__(
         self,
-        snakefile: TokenIterator,
+        snakefile: Snakefile,
         line_length: Optional[int] = None,
         black_config_file: Optional[PathLike] = None,
     ):
@@ -193,7 +190,7 @@ class Formatter(Parser):
         )
         try:
             fmted = black.format_str(string, mode=black_mode)
-        except black.InvalidInput as e:
+        except black.parsing.InvalidInput as e:
             err_msg = ""
             # Not clear whether all Black errors start with 'Cannot parse' - it seems to
             # in the tests I ran
@@ -228,61 +225,21 @@ class Formatter(Parser):
         """
         Takes an ensemble of strings and indents/reindents it
         """
-        pos = 0
         used_indent = TAB * target_indent
-        indented = ""
-        for match in re.finditer(full_string_matcher, string):
-            indented += textwrap.indent(string[pos : match.start(1)], used_indent)
-            lagging_spaces = len(indented) - len(indented.rstrip(" "))
-            lagging_indent_lvl = lagging_spaces // TAB_SIZE
-            match_slice = string[match.start(1) : match.end(1)].replace("\t", TAB)
-            all_lines = match_slice.splitlines(keepends=True)
-            first = textwrap.indent(textwrap.dedent(all_lines[0]), used_indent)
-            indented += first
-
-            is_multiline_string = re.match(
-                r"[bfru]?\"\"\"|'''", first.lstrip(), flags=re.IGNORECASE
-            )
-            if not is_multiline_string:
-                # this check if string is a single-quoted multiline string
-                # e.g. https://github.com/snakemake/snakefmt/issues/121
-                is_multiline_string = "\\\n" in first
-
-            if len(all_lines) > 2:
-                if is_multiline_string:
-                    middle = "".join(all_lines[1:-1])
-                else:
-                    mid = "".join(all_lines[1:-1])
-                    dedent_mid = textwrap.dedent(mid)
-
-                    if lagging_indent_lvl == 0:
-                        required_indent_lvl = target_indent
-                    else:
-                        current_indent_lvl = (len(mid) - len(mid.lstrip())) // TAB_SIZE
-                        required_indent_lvl = current_indent_lvl + target_indent
-
-                    required_indent = TAB * required_indent_lvl
-                    middle = textwrap.indent(
-                        dedent_mid,
-                        required_indent,
-                    )
-                indented += middle
-
-            if len(all_lines) > 1:
-                if is_multiline_string:
-                    last = all_lines[-1]
-                else:
-                    leading_spaces = len(all_lines[-1]) - len(
-                        textwrap.dedent(all_lines[-1])
-                    )
-                    leading_indent = leading_spaces // TAB_SIZE * TAB
-                    last = textwrap.indent(
-                        textwrap.dedent(all_lines[-1]), used_indent + leading_indent
-                    )
-                indented += last
-            pos = match.end()
-        indented += textwrap.indent(string[pos:], used_indent)
-
+        split_string = split_code_string(string)
+        if len(split_string) == 1:
+            return textwrap.indent(split_string[0], used_indent)
+        # First, masks all multi-line strings
+        fakewrap = textwrap.indent(
+            "".join('"""\n"""' if i % 2 else s for i, s in enumerate(split_string)),
+            used_indent,
+        )
+        split_code = fakewrap.split(textwrap.indent('"""\n"""', used_indent).strip())
+        # After indenting, we puts those strings back
+        indented = "".join(
+            s.replace("\t", TAB) if i % 2 else split_code[i // 2]
+            for i, s in enumerate(split_string)
+        )
         return indented
 
     def format_param(

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -331,7 +331,12 @@ class Formatter(Parser):
         result = f"{used_indent}{parameters.keyword_line}:"
         if inline_fmting:
             # here, check if the value is too large to put in one line
-            param = next(iter(parameters.all_params))
+            params_iter = iter(parameters.all_params)
+            try:
+                param = next(params_iter)
+            except StopIteration:
+                # No params; render just the keyword line and its comment.
+                return f"{result}{parameters.comment}\n"
             param_result = self.format_param(
                 param, target_indent, inline_fmting, param_list
             )

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -261,12 +261,10 @@ class Formatter(Parser):
             raise InvalidParameterSyntax(f"{parameter.line_nb}{val}") from None
 
         if inline_formatting or param_list:
-            val = " ".join(
-                val.rstrip().split("\n")
-            )  # collapse strings on multiple lines
+            val = val.rstrip()
         extra_spacing = 0
         if param_list:
-            val = f"f({val})"
+            val = f"f({val}\n)"
             extra_spacing = 3
 
         # get the index of the last character of the first docstring, if any

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -230,11 +230,15 @@ class Formatter(Parser):
         if len(split_string) == 1:
             return textwrap.indent(split_string[0], used_indent)
         # First, masks all multi-line strings
+        mask_string = "`~!@#$%^&*|?"
+        while mask_string in string:
+            mask_string += mask_string
+        mask_string = f'"""{mask_string}"""'
         fakewrap = textwrap.indent(
-            "".join('"""\n"""' if i % 2 else s for i, s in enumerate(split_string)),
+            "".join(mask_string if i % 2 else s for i, s in enumerate(split_string)),
             used_indent,
         )
-        split_code = fakewrap.split(textwrap.indent('"""\n"""', used_indent).strip())
+        split_code = fakewrap.split(mask_string)
         # After indenting, we puts those strings back
         indented = "".join(
             s.replace("\t", TAB) if i % 2 else split_code[i // 2]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 pytest_plugins = "pytester"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest import mock
 
 import black
+import black.const
 import click
 import pytest
 
@@ -19,7 +20,7 @@ from tests import setup_formatter
 
 
 def test_black_and_snakefmt_default_line_lengths_aligned():
-    assert DEFAULT_LINE_LENGTH == black.DEFAULT_LINE_LENGTH
+    assert DEFAULT_LINE_LENGTH == black.const.DEFAULT_LINE_LENGTH
 
 
 class TestFindPyprojectToml:
@@ -49,23 +50,24 @@ class TestConfigAdherence:
         actual = cli_runner.invoke(main, params, input=stdin)
         assert actual.exit_code == 0
 
-        expected_output = """include: \"a\"
-
-
-list_of_lots_of_things = [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-]
-"""
-        assert actual.output == expected_output
+        expected_output = (
+            'include: "a"\n'
+            "\n"
+            "\n"
+            "list_of_lots_of_things = [\n"
+            "    1,\n"
+            "    2,\n"
+            "    3,\n"
+            "    4,\n"
+            "    5,\n"
+            "    6,\n"
+            "    7,\n"
+            "    8,\n"
+            "    9,\n"
+            "    10,\n"
+            "]\n"
+        )
+        assert actual.stdout == expected_output
 
     def test_config_adherence_for_code_inside_rules(self, cli_runner, tmp_path):
         stdin = (
@@ -82,9 +84,9 @@ list_of_lots_of_things = [
 
             assert actual.exit_code == 0
             if expect_same:
-                assert actual.output == stdin
+                assert actual.stdout == stdin
             else:
-                assert actual.output != stdin
+                assert actual.stdout != stdin
 
 
 class TestReadSnakefmtDefaultsFromPyprojectToml:
@@ -254,7 +256,7 @@ class TestReadBlackConfig:
         with pytest.raises(MalformattedToml) as error:
             read_black_config(path)
 
-        assert error.match("invalid character")
+        assert error.match("Invalid statement")
 
     def test_skip_string_normalisation_handled_with_snakecase(self, tmp_path):
         formatter = setup_formatter("")

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -5,7 +5,6 @@ errors arise, as tested in test_parser.py.
 """
 
 import textwrap
-from io import StringIO
 from unittest import mock
 
 import pytest
@@ -13,7 +12,7 @@ import pytest
 from snakefmt.parser.grammar import SingleParam, SnakeGlobal
 from snakefmt.parser.syntax import COMMENT_SPACING
 from snakefmt.types import TAB
-from tests import Formatter, Snakefile, setup_formatter
+from tests import setup_formatter
 
 
 def test_emptyInput_emptyOutput():
@@ -27,9 +26,8 @@ def test_emptyInput_emptyOutput():
 
 class TestSimpleParamFormatting:
     def test_simple_rule_one_input(self):
-        stream = StringIO("rule a:\n" f'{TAB * 1}input: "foo.txt"')
-        smk = Snakefile(stream)
-        formatter = Formatter(smk)
+        stream = "rule a:\n" f'{TAB * 1}input: "foo.txt"'
+        formatter = setup_formatter(stream)
 
         actual = formatter.get_formatted()
         expected = "rule a:\n" f"{TAB * 1}input:\n" f'{TAB * 2}"foo.txt",\n'
@@ -208,16 +206,13 @@ class TestComplexParamFormatting:
     """
 
     def test_expand_as_param(self):
-        stream = StringIO(
+        formatter = setup_formatter(
             "rule a:\n"
             f"{TAB * 1}input: \n"
             f"{TAB * 2}"
             'expand("{f}/{p}", f = [1, 2], p = ["1", "2"])\n'
             f'{TAB * 1}output:"foo.txt","bar.txt"\n'
         )
-
-        smk = Snakefile(stream)
-        formatter = Formatter(smk)
         actual = formatter.get_formatted()
 
         expected = (
@@ -264,7 +259,7 @@ class TestComplexParamFormatting:
         We need to ignore 'input:' as a recognised keyword and ',' inside brackets
         Ie, the lambda needs to be parsed as a parameter.
         """
-        snakefile = (
+        snakecode = (
             f"rule a:\n"
             f"{TAB * 1}input:\n"
             f'{TAB * 2}"foo.txt",\n'
@@ -273,10 +268,10 @@ class TestComplexParamFormatting:
             'obs=lambda w, input: ["{}={}".format(s, f) for s, f in zip(get(w), input.obs)],\n'  # noqa: E501  due to readability of test
             f"{TAB * 2}p2=2,\n"
         )
-        formatter = setup_formatter(snakefile)
+        formatter = setup_formatter(snakecode)
 
         actual = formatter.get_formatted()
-        expected = snakefile
+        expected = snakecode
         assert actual == expected
 
     def test_arg_and_kwarg_unpacking(self):
@@ -293,6 +288,36 @@ class TestComplexParamFormatting:
         formatter = setup_formatter(snakecode)
         actual = formatter.get_formatted()
         assert actual == snakecode
+
+    def test_arg_very_looong(self):
+        """issue 190"""
+        snakecode = (
+            "if 1:\n"
+            "\n"
+            "    rule a:\n"
+            "        input:\n"
+            '            a="a",\n'
+            "        run:\n"
+            "            for i in range(3):\n"
+            "                a = list(\n"
+            '                    "a",\n'
+            '                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",\n'
+            "                )\n"
+            "                b = list(\n"
+            "                    ''.format(\n"
+            '                        "sssssssssssssssssssssssssssssssssssssssssssssssss",\n'
+            '                        b="b"\n'
+            "                    )\n"
+            "                )\n"
+            "\n"
+            "    rule b:\n"
+            "        shell:\n"
+            '            "echo 1"\n'
+            "\n"
+        )
+        formatter = setup_formatter(snakecode)
+        actual = formatter.get_formatted()
+        assert actual == setup_formatter(actual).get_formatted()
 
 
 class TestSimplePythonFormatting:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -341,15 +341,25 @@ class TestComplexParamFormatting:
         actual = setup_formatter(snakecode).get_formatted()
         assert actual == expected
 
-    def test_param_inline_formatting(self):
-        """issue 208, 240 and 242"""
+    def test_param_comment_multiline(self):
+        """issue 208"""
         snakecode = (
             f"rule call_variants:\n"
             f"{TAB * 1}input:\n"
             f"{TAB * 2}data=(\n"
             f"{TAB * 3}# a comment on the below\n"
             f'{TAB * 3}"input_1.txt"\n'
+            f"{TAB * 3}if condition\n"
+            f'{TAB * 3}else "input_2.txt"\n'
             f"{TAB * 2}),\n"
+        )
+        actual = setup_formatter(snakecode).get_formatted()
+        assert actual == snakecode
+
+    def test_param_inline_formatting(self):
+        """issue 240 and 242"""
+        snakecode = (
+            f"rule call_variants:\n"
             f"{TAB * 1}threads:\n"
             f"{TAB * 2}max(\n"
             f"{TAB * 3}1,\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -294,50 +294,71 @@ class TestComplexParamFormatting:
         snakecode = (
             "if 1:\n"
             "\n"
-            "    rule a:\n"
-            "        input:\n"
-            '            a="a",\n'
-            "        run:\n"
-            "            for i in range(3):\n"
-            "                a = list(\n"
-            '                    "a",\n'
-            '                    "' + ("a" * 68) + '",\n'
-            "                )\n"
-            "                b = list(\n"
-            "                    ''.format(\n"
-            '                        "' + ("b" * 117) + '",\n'
-            '                        b="b"\n'
-            "                    )\n"
-            "                )\n"
+            " rule a:\n"
+            "  input:\n"
+            '   a="a",\n'
+            "  run:\n"
+            "   for i in range(3):\n"
+            "    a = list(\n"
+            '     "a",\n'
+            '     "' + ("a" * 68) + '",\n'
+            "    )\n"
+            "    b = list(\n"
+            "     ''.format(\n"
+            '      "' + ("b" * 117) + '",\n'
+            '      b="b"\n'
+            "     )\n"
+            "    )\n"
             "\n"
-            "    rule b:\n"
-            "        shell:\n"
-            '            "echo 1"\n'
+            " rule b:\n"
+            "  shell:\n"
+            '   "echo 1"\n'
             "\n"
         )
-        formatter = setup_formatter(snakecode)
-        actual = formatter.get_formatted()
-        assert actual == setup_formatter(actual).get_formatted()
+        expected = (
+            f"if 1:\n"
+            f"\n"
+            f"{TAB * 1}rule a:\n"
+            f"{TAB * 2}input:\n"
+            f'{TAB * 3}a="a",\n'
+            f"{TAB * 2}run:\n"
+            f"{TAB * 3}for i in range(3):\n"
+            f"{TAB * 4}a = list(\n"
+            f'{TAB * 5}"a",\n'
+            f'{TAB * 5}"' + ("a" * 68) + '",\n'
+            f"{TAB * 4})\n"
+            f"{TAB * 4}b = list(\n"
+            f'{TAB * 5}"".format(\n'
+            f'{TAB * 6}"' + ("b" * 117) + '",\n'
+            f'{TAB * 6}b="b",\n'
+            f"{TAB * 5})\n"
+            f"{TAB * 4})\n"
+            f"\n"
+            f"{TAB * 1}rule b:\n"
+            f"{TAB * 2}shell:\n"
+            f'{TAB * 3}"echo 1"\n'
+        )
+        actual = setup_formatter(snakecode).get_formatted()
+        assert actual == expected
 
     def test_param_inline_formatting(self):
-        """issue 240 and 242"""
+        """issue 208, 240 and 242"""
         snakecode = (
-            "rule call_variants:\n"
-            "    input:\n"
-            "        data=(\n"
-            "            # a comment on the below\n"
-            '            "input_1.txt"\n'
-            "        ),\n"
-            "    threads:\n"
-            "        max(\n"
-            "            1,\n"
-            '            int(config["params"]["call_variants"]["threads"]) -\n'
-            '            int(config["params"]["call_variants"]["compress-threads"])\n'
-            "        )\n"
+            f"rule call_variants:\n"
+            f"{TAB * 1}input:\n"
+            f"{TAB * 2}data=(\n"
+            f"{TAB * 3}# a comment on the below\n"
+            f'{TAB * 3}"input_1.txt"\n'
+            f"{TAB * 2}),\n"
+            f"{TAB * 1}threads:\n"
+            f"{TAB * 2}max(\n"
+            f"{TAB * 3}1,\n"
+            f'{TAB * 3}int(config["params"]["call_variants"]["threads"])\n'
+            f'{TAB * 3}- int(config["params"]["call_variants"]["compress-threads"]),\n'
+            f"{TAB * 2})\n"
         )
-        formatter = setup_formatter(snakecode)
-        actual = formatter.get_formatted()
-        assert actual == setup_formatter(actual).get_formatted()
+        actual = setup_formatter(snakecode).get_formatted()
+        assert actual == snakecode
 
 
 class TestSimplePythonFormatting:
@@ -1197,7 +1218,7 @@ class TestNewlineSpacing:
             assert formatter.get_formatted() == replaced
 
     def test_repeated_parameter_keyword_comment_in_between_no_spacing(self):
-        snakecode = 'include: "a"\n# A comment\n # c2\ninclude: "b"\n'
+        snakecode = 'include: "a"\n# A comment\n' ' # c2\ninclude: "b"\n'
         expected = 'include: "a"\n# A comment\n# c2\ninclude: "b"\n'
         assert setup_formatter(snakecode).get_formatted() == expected
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -319,6 +319,23 @@ class TestComplexParamFormatting:
         actual = formatter.get_formatted()
         assert actual == setup_formatter(actual).get_formatted()
 
+    def test_long_parenthesis(self):
+        """issue 240"""
+        snakecode = (
+            "rule call_variants:\n"
+            "    input:\n"
+            "        some_file\n"
+            "    threads:\n"
+            "        max(\n"
+            "            1,\n"
+            '            int(config["params"]["call_variants"]["threads"]) -\n'
+            '            int(config["params"]["call_variants"]["compress-threads"])\n'
+            "        )\n"
+        )
+        formatter = setup_formatter(snakecode)
+        actual = formatter.get_formatted()
+        assert actual == setup_formatter(actual).get_formatted()
+
 
 class TestSimplePythonFormatting:
     @mock.patch(
@@ -497,7 +514,7 @@ class TestComplexPythonFormatting:
         ) as mock_m:
             mock_m.return_value = "b=2\nif condition:\n"
             setup_formatter(snakecode)
-            assert mock_m.call_count == 2
+            assert mock_m.call_count == 3
 
         formatter = setup_formatter(snakecode)
         expected = "b = 2\n" "if condition:\n\n" f'{TAB * 1}include: "a"\n'

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -319,12 +319,15 @@ class TestComplexParamFormatting:
         actual = formatter.get_formatted()
         assert actual == setup_formatter(actual).get_formatted()
 
-    def test_long_parenthesis(self):
-        """issue 240"""
+    def test_param_inline_formatting(self):
+        """issue 240 and 242"""
         snakecode = (
             "rule call_variants:\n"
             "    input:\n"
-            "        some_file\n"
+            "        data=(\n"
+            "            # a comment on the below\n"
+            '            "input_1.txt"\n'
+            "        ),\n"
             "    threads:\n"
             "        max(\n"
             "            1,\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -301,11 +301,11 @@ class TestComplexParamFormatting:
             "            for i in range(3):\n"
             "                a = list(\n"
             '                    "a",\n'
-            '                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",\n'
+            '                    "' + ("a" * 68) + '",\n'
             "                )\n"
             "                b = list(\n"
             "                    ''.format(\n"
-            '                        "sssssssssssssssssssssssssssssssssssssssssssssssss",\n'
+            '                        "' + ("b" * 117) + '",\n'
             '                        b="b"\n'
             "                    )\n"
             "                )\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -341,8 +341,36 @@ class TestComplexParamFormatting:
         actual = setup_formatter(snakecode).get_formatted()
         assert actual == expected
 
-    def test_param_comment_multiline(self):
+    def test_param_inline_formatting_long(self):
         """issue 208"""
+        snakecode = (
+            f"rule call_variants:\n"
+            f'{TAB * 1}output: "test"\n'
+            f"{TAB * 1}threads: lambda wildcards, input: get_number_of_COBS_threads"
+            "(wildcards, input, predefined_cobs_threads, streaming)\n"
+            f"{TAB * 1}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}touch {{output}}\n"
+            f'{TAB * 2}"""\n'
+        )
+        expected = (
+            f"rule call_variants:\n"
+            f"{TAB * 1}output:\n"
+            f'{TAB * 2}"test",\n'
+            f"{TAB * 1}threads:\n"
+            f"{TAB * 2}lambda wildcards, input: get_number_of_COBS_threads(\n"
+            f"{TAB * 3}wildcards, input, predefined_cobs_threads, streaming\n"
+            f"{TAB * 2})\n"
+            f"{TAB * 1}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}touch {{output}}\n"
+            f'{TAB * 2}"""\n'
+        )
+        actual = setup_formatter(snakecode).get_formatted()
+        assert actual == expected
+
+    def test_param_comment_multiline(self):
+        """issue 240 and 242"""
         snakecode = (
             f"rule call_variants:\n"
             f"{TAB * 1}input:\n"
@@ -352,14 +380,6 @@ class TestComplexParamFormatting:
             f"{TAB * 3}if condition\n"
             f'{TAB * 3}else "input_2.txt"\n'
             f"{TAB * 2}),\n"
-        )
-        actual = setup_formatter(snakecode).get_formatted()
-        assert actual == snakecode
-
-    def test_param_inline_formatting(self):
-        """issue 240 and 242"""
-        snakecode = (
-            f"rule call_variants:\n"
             f"{TAB * 1}threads:\n"
             f"{TAB * 2}max(\n"
             f"{TAB * 3}1,\n"

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -6,7 +6,7 @@ from typing import Optional
 from unittest import mock
 
 import pytest
-from black import get_gitignore
+from black.files import get_gitignore
 
 from snakefmt.diff import ExitCode
 from snakefmt.formatter import TAB
@@ -15,8 +15,7 @@ from snakefmt.snakefmt import construct_regex, get_snakefiles_in_dir, main
 
 class TestCLIBasic:
     def test_noArgsPassed_printsNothingToDo(self, cli_runner):
-        params = []
-        actual = cli_runner.invoke(main, params)
+        actual = cli_runner.invoke(main, [])
         assert actual.exit_code == 0
         assert "Nothing to do" in actual.stderr
 
@@ -51,7 +50,7 @@ class TestCLIBasic:
 
         expected_output = f'rule all:\n{TAB}input:\n{TAB*2}"c",\n'
 
-        assert actual.output == expected_output
+        assert actual.stdout == expected_output
 
     def test_src_dir_arg_files_modified_inplace(self, cli_runner):
         with tempfile.TemporaryDirectory(dir=".") as tmpdir:
@@ -186,7 +185,7 @@ class TestCLICheck:
 
         assert ExitCode(result.exit_code) is ExitCode.WOULD_CHANGE
         expected_output = "=====> Diff for stdin <=====\n\n- x='foo'\n+ x = \"foo\"\n\n"
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_check_and_diff_doesnt_output_diff_if_error(self, cli_runner):
         stdin = "rule:rule:\n"
@@ -195,7 +194,7 @@ class TestCLICheck:
         result = cli_runner.invoke(main, params, input=stdin)
 
         assert ExitCode(result.exit_code) is ExitCode.ERROR
-        assert result.output == ""
+        assert result.stdout == ""
 
 
 class TestCLIDiff:
@@ -217,7 +216,7 @@ class TestCLIDiff:
             "?          ^ ^\n\n"
         )
 
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_compact_diff_works_as_expected(self, cli_runner):
         stdin = "include: 'a'\n"
@@ -238,7 +237,7 @@ class TestCLIDiff:
             '+include: "a"\n\n'
         )
 
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_compact_diff_and_diff_given_runs_compact_diff(self, cli_runner):
         stdin = "include: 'a'\n"
@@ -259,7 +258,7 @@ class TestCLIDiff:
             '+include: "a"\n\n'
         )
 
-        assert result.output == expected_output
+        assert result.stdout == expected_output
 
     def test_diff_does_not_format_file(self, cli_runner, tmp_path):
         content = "include: 'a'\nlist_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8]"
@@ -284,7 +283,7 @@ class TestCLIDiff:
 
         assert isinstance(result.exception, SyntaxError)
         assert result.exit_code != 0
-        assert result.output == ""
+        assert result.stdout == ""
 
 
 class TestConstructRegex:
@@ -363,13 +362,13 @@ class TestCLIValidRegex:
                 with (abs_tmpdir / ".gitignore").open("w") as fout:
                     fout.write(gitignored)
                 gitignore = get_gitignore(abs_tmpdir)
-            snakefiles = get_snakefiles_in_dir(
+            smks = get_snakefiles_in_dir(
                 path=abs_tmpdir,
                 include=include,
                 exclude=exclude,
                 gitignore=gitignore,
             )
-            snakefiles = list(map(lambda p: str(p.relative_to(abs_tmpdir)), snakefiles))
+            snakefiles = list(map(lambda p: str(p.relative_to(abs_tmpdir)), smks))
         return Counter(snakefiles)
 
     @mock.patch("pathspec.PathSpec")
@@ -379,8 +378,7 @@ class TestCLIValidRegex:
         exclude = re.compile(r".*")
 
         actual = self.find_files_to_format(include, exclude, mock_gitignore)
-        expected = Counter()
-        assert actual == expected
+        assert actual == Counter()
 
     @mock.patch("pathspec.PathSpec")
     def test_includeAllFiles_returnAll(self, mock_gitignore: mock.MagicMock):


### PR DESCRIPTION
will fix #190.

and also fix #208 and fix #240, now the "one-line" format will fall back to normal style,
and also fix #242, just let black to merge lines and handle comments.
and also close #255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer handling of multi-piece strings and f-strings for more robust formatting.
  * More compact and stable inline parameter formatting.

* **Bug Fixes**
  * Improved consistency of indentation and alignment for complex strings and parameters.
  * Updated parsing error messages for clearer diagnostics.

* **Chores**
  * Updated supported Python targets to 3.11–3.13; CI matrix adjusted.
  * Switched config parsing to Python's stdlib TOML reader.

* **Tests**
  * CLI tests now assert stdout; added regression tests for complex parameter cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->