### PR TITLE
feat!: format shell directives using shfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ design and specifications of [Black][black].
 > **Recent Changes:**
 > 1. **Rule and module directives are now sorted by default:** `snakefmt` will automatically sort the order of directives inside rules (e.g. `input`, `output`, `shell`) and modules into a consistent order. You can opt out of this by using the `--no-sort` CLI flag.
 > 2. **Black upgraded to v26:** The underlying `black` formatter has been upgraded to v26. You will see changes in how implicitly concatenated strings are wrapped (they are now collapsed onto a single line if they fit within the line limit) and other minor adjustments compared to previous versions.
+> 3. **Shell blocks are now formatted using `shfmt`:** `snakefmt` now formats the body of `shell:` directives using [`shfmt`](https://github.com/mvdan/sh). This is enabled by default and will reformat shell code that was previously left untouched. You can opt out with `--no-format-shell` (`-F`) or `format_shell = false` in `pyproject.toml`. See [Shell Block Formatting](#shell-block-formatting) for details.
 >
 > **Example of expected differences:**
 > ```python
@@ -46,7 +47,7 @@ design and specifications of [Black][black].
 
 [TOC]: #
 
-# Table of Contents
+## Table of Contents
 - [Install](#install)
   - [PyPi](#pypi)
   - [Conda](#conda)
@@ -56,6 +57,7 @@ design and specifications of [Black][black].
 - [Usage](#usage)
   - [Basic Usage](#basic-usage)
   - [Full Usage](#full-usage)
+  - [Shell Block Formatting](#shell-block-formatting)
   - [Directive Sorting](#directive-sorting)
   - [Format Directives](#format-directives)
   - [Configuration](#configuration)
@@ -246,41 +248,45 @@ Usage: snakefmt [OPTIONS] [SRC]...
   Snakefile` to avoid this.
 
 Options:
-  -l, --line-length INT       Lines longer than INT will be wrapped. [default:
-                              88]
-  -s, --sort / -S, --no-sort  Sort directives in rules and modules.  [default:
-                              sort]
-  --check                     Don't write the files back, just return the
-                              status. Return code 0 means nothing would
-                              change. Return code 1 means some files would be
-                              reformatted. Return code 123 means there was an
-                              error.
-  -d, --diff                  Don't write the files back, just output a diff
-                              for each file to stdout.
-  --compact-diff              Same as --diff but only shows lines that would
-                              change plus a few lines of context.
-  --include PATTERN           A regular expression that matches files and
-                              directories that should be included on recursive
-                              searches.  An empty value means all files are
-                              included regardless of the name.  Use forward
-                              slashes for directories on all platforms
-                              (Windows, too).  Exclusions are calculated
-                              first, inclusions later.  [default:
-                              (\.smk$|^Snakefile)]
-  --exclude PATTERN           A regular expression that matches files and
-                              directories that should be excluded on recursive
-                              searches.  An empty value means no paths are
-                              excluded. Use forward slashes for directories on
-                              all platforms (Windows, too). Exclusions are
-                              calculated first, inclusions later.  [default: (
-                              \.snakemake/|\.eggs/|\.git/|\.hg/|\.mypy_cache/|
-                              \.nox/|\.tox/|\.venv/|\.svn/|_build/|buck-
-                              out/|/build/|/dist/|\.template/)]
-  -c, --config PATH           Read configuration from PATH. By default, will
-                              try to read from `./pyproject.toml`
-  -h, --help                  Show this message and exit.
-  -V, --version               Show the version and exit.
-  -v, --verbose               Turns on debug-level logger.
+  -l, --line-length INT           Lines longer than INT will be wrapped.
+                                  [default: 88]
+  -s, --sort / -S, --no-sort      Sort directives in rules and modules.
+                                  [default: sort]
+  -f, --format-shell / -F, --no-format-shell
+                                  Format shell directives using shfmt.
+                                  [default: format-shell]
+  --check                         Don't write the files back, just return the
+                                  status. Return code 0 means nothing would
+                                  change. Return code 1 means some files would
+                                  be reformatted. Return code 123 means there
+                                  was an error.
+  -d, --diff                      Don't write the files back, just output a
+                                  diff for each file to stdout.
+  --compact-diff                  Same as --diff but only shows lines that
+                                  would change plus a few lines of context.
+  --include PATTERN               A regular expression that matches files and
+                                  directories that should be included on
+                                  recursive searches.  An empty value means
+                                  all files are included regardless of the
+                                  name.  Use forward slashes for directories
+                                  on all platforms (Windows, too).  Exclusions
+                                  are calculated first, inclusions later.
+                                  [default: (\.smk$|^Snakefile)]
+  --exclude PATTERN               A regular expression that matches files and
+                                  directories that should be excluded on
+                                  recursive searches.  An empty value means no
+                                  paths are excluded. Use forward slashes for
+                                  directories on all platforms (Windows, too).
+                                  Exclusions are calculated first, inclusions
+                                  later.  [default: (\.snakemake/|\.eggs/|\.gi
+                                  t/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/
+                                  |\.svn/|_build/|buck-
+                                  out/|/build/|/dist/|\.template/)]
+  -c, --config PATH               Read configuration from PATH. By default,
+                                  will try to read from `./pyproject.toml`
+  -h, --help                      Show this message and exit.
+  -V, --version                   Show the version and exit.
+  -v, --verbose                   Turns on debug-level logger.
 ```
 
 ### Directive Sorting
@@ -301,6 +307,88 @@ Directives are grouped by their functional role in the following order:
 This ordering ensures that the directives most frequently used in execution blocks (like `threads`, `resources`, and `params`) are placed immediately above the action directive.
 
 You can disable this feature using the `--no-sort` flag.
+
+### Shell Block Formatting
+
+By default, `snakefmt` formats the body of `shell:` directives using [`shfmt`](https://github.com/mvdan/sh).
+This keeps shell snippets in your Snakefiles formatted consistently and avoids cosmetic diffs triggering unnecessary Snakemake re-runs.
+
+#### Example
+
+Before:
+
+```python
+rule align:
+    input:
+        "reads.fq",
+    output:
+        "aligned.bam",
+    threads: 4
+    shell:
+        """
+        bwa mem -t {threads} ref.fa {input} | samtools sort -o {output} -
+        if [ -s {output} ]
+        then
+        echo "done"
+        else
+        echo "empty"
+        exit 1
+        fi
+        """
+```
+
+After:
+
+```python
+rule align:
+    input:
+        "reads.fq",
+    output:
+        "aligned.bam",
+    threads: 4
+    shell:
+        """
+        bwa mem -t {threads} ref.fa {input} | samtools sort -o {output} -
+        if [ -s {output} ]; then
+            echo "done"
+        else
+            echo "empty"
+            exit 1
+        fi
+        """
+```
+
+#### Disabling
+
+You can disable shell formatting on the command line with `--no-format-shell` (`-F`), or in `pyproject.toml`:
+
+```toml
+[tool.snakefmt]
+format_shell = false
+```
+
+`shfmt` is invoked with `-i 4 -ci -bn` (four-space indentation, indented switch cases, binary operators may start a line).
+
+#### Snakemake placeholders
+
+Snakemake `{var}` placeholders are masked before `shfmt` runs so it does not mis-parse them, then restored verbatim afterwards.
+Escaped double-brace placeholders such as those required by `awk` are passed through unchanged:
+
+```python
+rule example:
+    shell:
+        """
+        awk '{{print $1}}' {input} > {output}
+        """
+```
+
+#### Invalid shell
+
+If `shfmt` cannot parse the shell body, `snakefmt` raises an `InvalidShell` error rather than silently leaving the block unformatted.
+To work around malformed (or intentionally non-standard) shell, either:
+
+- Disable shell formatting for the whole run with `-F` / `--no-format-shell`, or
+- Wrap the rule in `# fmt: off` / `# fmt: on` directives (see below) to opt that block out.
 
 ### Format Directives
 
@@ -405,6 +493,8 @@ configuration file.
 [tool.snakefmt]
 line_length = 90
 include = '\.smk$|^Snakefile|\.py$'
+sort_directives = true   # sort rule directives into a consistent order (default: true)
+format_shell = true      # format shell: blocks with shfmt (default: true)
 
 # snakefmt passes these options on to black
 [tool.black]
@@ -433,7 +523,7 @@ To do so, create the file `.pre-commit-config.yaml` in the root of your project 
 ```yaml
 repos:
   - repo: https://github.com/snakemake/snakefmt
-    rev: v0.10.2 # Replace by any tag/version ≥v0.6.0 : https://github.com/snakemake/snakefmt/releases
+    rev: v1.1.0 # Replace by any tag/version ≥v0.6.0 : https://github.com/snakemake/snakefmt/releases
     hooks:
       - id: snakefmt
 ```

--- a/README.md
+++ b/README.md
@@ -395,10 +395,29 @@ simplicity and safety.
 If you need `shfmt` to format the body of a brace group, wrap it in `# fmt: off` / `# fmt: on`
 and format that section manually.
 
+#### Heredoc handling
+
+`snakefmt` masks heredoc bodies before passing shell code to `shfmt`, and restores them afterwards. This means:
+
+- **Heredoc bodies are never reformatted** — `shfmt` does not reformat heredoc content, and neither does `snakefmt`.
+- **Snakemake-style escape prefixes on the terminator are supported.** For example, a heredoc that ends with `\n!EOF!` instead of a bare `!EOF!` at column 0 is detected and handled correctly — no `# fmt: off` required.
+
+```
+shell:
+    """
+    python <<!EOF!
+    \nif True:
+        print("hello")
+    \n!EOF!
+    """
+```
+
+Standard heredoc forms (`<<EOF`, `<<-EOF`, `<<'EOF'`) are also supported and the terminator placement requirement (column 0 for `<<EOF`, leading tabs only for `<<-EOF`) is preserved after formatting.
+
 #### Invalid shell
 
 If `shfmt` cannot parse the shell body, `snakefmt` raises an `InvalidShell` error rather than silently leaving the block unformatted.
-To work around malformed (or intentionally non-standard) shell, either:
+To work around genuinely invalid shell, either:
 
 - Disable shell formatting for the whole run with `-F` / `--no-format-shell`, or
 - Wrap the rule in `# fmt: off` / `# fmt: on` directives (see below) to opt that block out.

--- a/README.md
+++ b/README.md
@@ -382,6 +382,18 @@ rule example:
         """
 ```
 
+#### Brace groups
+
+Bash brace groups (`{ cmd1; cmd2; }`) appear as `{{ cmd1; cmd2; }}` in Snakemake shell strings
+because Snakemake renders the block through `str.format()`, which requires `{{` / `}}` to produce
+literal `{` / `}`. `snakefmt` preserves these double-brace sequences verbatim — the body inside
+a brace group is **not** internally reformatted by `shfmt`. This is intentional: reformatting the
+body would require splitting the `{{` / `}}` delimiters, which would break `str.format()` at
+runtime.
+
+If you need `shfmt` to format the body of a brace group, wrap it in `# fmt: off` / `# fmt: on`
+and format that section manually.
+
 #### Invalid shell
 
 If `shfmt` cannot parse the shell body, `snakefmt` raises an `InvalidShell` error rather than silently leaving the block unformatted.

--- a/README.md
+++ b/README.md
@@ -387,9 +387,10 @@ rule example:
 Bash brace groups (`{ cmd1; cmd2; }`) appear as `{{ cmd1; cmd2; }}` in Snakemake shell strings
 because Snakemake renders the block through `str.format()`, which requires `{{` / `}}` to produce
 literal `{` / `}`. `snakefmt` preserves these double-brace sequences verbatim — the body inside
-a brace group is **not** internally reformatted by `shfmt`. This is intentional: reformatting the
-body would require splitting the `{{` / `}}` delimiters, which would break `str.format()` at
-runtime.
+a brace group is **not** internally reformatted by `shfmt`. This is an implementation trade-off:
+safely unescaping, formatting, and re-escaping the contents without disrupting Snakemake's
+variable interpolation introduces significant parser complexity, so opaque masking is used for
+simplicity and safety.
 
 If you need `shfmt` to format the body of a brace group, wrap it in `# fmt: off` / `# fmt: on`
 and format that section manually.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ snakefmt - < Snakefile
 
 ### Full Usage
 
+<details>
+<summary>Show full help output</summary>
+
 ```
 $ snakefmt --help
 Usage: snakefmt [OPTIONS] [SRC]...
@@ -289,9 +292,14 @@ Options:
   -v, --verbose                   Turns on debug-level logger.
 ```
 
+</details>
+
 ### Directive Sorting
 
 By default, `snakefmt` sorts rule and module directives (like `input`, `output`, `shell`, etc.) into a consistent order. This makes rules easier to read and allows for quicker cross-referencing between inputs, outputs, and the resources used by the execution command.
+
+<details>
+<summary>Directive ordering details</summary>
 
 Directives are grouped by their functional role in the following order:
 
@@ -305,6 +313,8 @@ Directives are grouped by their functional role in the following order:
 8.  **Action**: `shell`, `run`, `script`, `notebook`, `wrapper`, `cwl`, `template_engine`
 
 This ordering ensures that the directives most frequently used in execution blocks (like `threads`, `resources`, and `params`) are placed immediately above the action directive.
+
+</details>
 
 You can disable this feature using the `--no-sort` flag.
 
@@ -369,6 +379,9 @@ format_shell = false
 
 `shfmt` is invoked with `-i 4 -ci -bn` (four-space indentation, indented switch cases, binary operators may start a line).
 
+<details>
+<summary>Advanced details: placeholders, heredocs, brace groups, invalid shell</summary>
+
 #### Snakemake placeholders
 
 Snakemake `{var}` placeholders are masked before `shfmt` runs so it does not mis-parse them, then restored verbatim afterwards.
@@ -422,6 +435,8 @@ To work around genuinely invalid shell, either:
 - Disable shell formatting for the whole run with `-F` / `--no-format-shell`, or
 - Wrap the rule in `# fmt: off` / `# fmt: on` directives (see below) to opt that block out.
 
+</details>
+
 ### Format Directives
 
 `snakefmt` supports comment directives to control formatting behaviour for specific regions of code.
@@ -453,6 +468,9 @@ rule c:
 ```
 
 > **Note:** inside `run:` blocks and other Python contexts, `# fmt: off` / `# fmt: on` is passed through to [Black][black], which handles it natively.
+
+<details>
+<summary>Additional directives: <code># fmt: off[sort]</code>, <code># fmt: off[next]</code>, <code># fmt: skip</code></summary>
 
 #### `# fmt: off[sort]`
 
@@ -502,6 +520,8 @@ rule also_formatted:
 
 > **Note:** `# fmt: skip` is not yet supported within Snakemake rule blocks.
 > It currently applies only to plain Python lines outside of rules, checkpoints, and similar Snakemake constructs.
+
+</details>
 
 ### Configuration
 
@@ -566,7 +586,11 @@ Then [install pre-commit](https://pre-commit.com/#installation) and initialize t
 
 [GitHub Actions](https://github.com/features/actions) in combination with [super-linter](https://github.com/github/super-linter) allows you to automatically run `snakefmt` on all Snakefiles in your repository e.g. whenever you push a new commit.
 
-To do so, create the file `.github/workflows/linter.yml` in your repository:
+<details>
+<summary>Show GitHub Actions workflow configuration</summary>
+
+Create `.github/workflows/linter.yml` in your repository:
+
 ```yaml
 ---
 name: Lint
@@ -607,10 +631,13 @@ jobs:
 ```
 
 Additional configuration parameters can be specified by creating `.github/linters/.snakefmt.toml`:
+
 ```toml
 [tool.black]
 skip_string_normalization = true
 ```
+
+</details>
 
 For more information check the `super-linter` readme.
 
@@ -620,6 +647,9 @@ If you can't get enough of badges, then feel free to show others you're using `s
 in your project.
 
 [![Code style: snakefmt](https://img.shields.io/badge/code%20style-snakefmt-000000.svg)](https://github.com/snakemake/snakefmt)
+
+<details>
+<summary>Copy badge markup</summary>
 
 ### Markdown
 
@@ -634,6 +664,8 @@ in your project.
     :target: https://github.com/snakemake/snakefmt
 ```
 
+</details>
+
 ## Changes
 
 See [`CHANGELOG.md`][changes].
@@ -646,7 +678,10 @@ See [CONTRIBUTING.md][contributing].
 
 [![DOI][doi-shield]][doi]
 
-```Bibtex
+<details>
+<summary>BibTeX</summary>
+
+```bibtex
 @article{snakemake2021,
   doi = {10.12688/f1000research.29032.2},
   url = {https://doi.org/10.12688/f1000research.29032.2},
@@ -660,6 +695,8 @@ See [CONTRIBUTING.md][contributing].
   journal = {F1000Research}
 }
 ```
+
+</details>
 
 
 [snakemake]: https://snakemake.readthedocs.io/

--- a/docs/adr/0001-shell-formatter-distribution.md
+++ b/docs/adr/0001-shell-formatter-distribution.md
@@ -2,6 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-13
+- **Updated:** 2026-05-14
 
 ## Context
 
@@ -68,6 +69,27 @@ across any future backend.
 - The shell-formatter call site is structured so that, if any of the revisit
   triggers fires, the replacement work is contained to the implementation of
   `_invoke_shfmt` (or its successor) in `snakefmt/shell_formatter.py`.
+
+## Update — 2026-05-14
+
+`shfmt-py` v4.0.0 was released on 2026-05-13, directly addressing both concerns
+that prompted this ADR:
+
+1. **Version lag resolved:** v4.0.0 bundles shfmt v3.13.1 (the current upstream
+   release at the time of writing).
+2. **Maintenance cadence improved:** The maintainer added Renovate bot automation
+   (PR #40/#57), which will open automated PRs whenever upstream shfmt releases a
+   new version. The single-maintainer lag risk is substantially reduced.
+3. **Versioning decoupled:** The package version (`4.x`) is now independent of the
+   bundled shfmt version. `SHFMT_VERSION` in `setup.py` tracks the binary
+   separately. This means pip version ranges no longer need to encode shfmt minor
+   versions.
+4. **Platform fallback added:** If no pre-built binary exists for a platform,
+   `shfmt-py` now falls back to a system `shfmt` on PATH rather than failing.
+
+The `pyproject.toml` constraint was updated to `shfmt-py>=4.0.0,<5.0.0`.
+None of the revisit triggers fired; the decision to depend on `shfmt-py` remains
+correct and the risk profile has improved materially.
 
 ## Revisit triggers
 

--- a/docs/adr/0001-shell-formatter-distribution.md
+++ b/docs/adr/0001-shell-formatter-distribution.md
@@ -1,0 +1,93 @@
+# ADR-0001: Distribution mechanism for the `shfmt` dependency
+
+- **Status:** Accepted
+- **Date:** 2026-05-13
+
+## Context
+
+`snakefmt` formats the body of Snakemake `shell:` directives by invoking
+[`shfmt`](https://github.com/mvdan/sh), a Go binary that formats POSIX shell,
+Bash, and (since 3.13) Zsh. The integration is implemented in
+`snakefmt/shell_formatter.py` and shells out to the `shfmt` executable via
+`subprocess.run`.
+
+The Go binary is currently delivered as a Python wheel by
+[`shfmt-py`](https://github.com/MaxWinterstein/shfmt-py), pinned in
+`pyproject.toml` as `shfmt-py>=3.12.0.2`. `shfmt-py` mirrors upstream `shfmt`
+releases by downloading the official release artefact and packaging it inside a
+wheel that installs an `shfmt` console script onto `PATH`, in the same way
+`shellcheck-py` does for ShellCheck.
+
+`shfmt-py` is maintained by a single author and currently lags upstream by one
+minor version (`3.12.0` vs `shfmt` 3.13.1 at the time of writing). This
+prompted a review of the distribution mechanism: should `snakefmt` continue to
+depend on `shfmt-py`, or should it own its `shfmt` delivery so it can decouple
+from a single-maintainer upstream?
+
+### Alternatives considered
+
+1. **Fork `shfmt-py` (or build an equivalent wheel-vendoring package).**
+   `snakefmt` would publish wheels that bundle the `shfmt` binary for each
+   supported platform. This is the most direct path to distribution control —
+   `snakefmt` could ship a newer `shfmt` whenever it wants and is no longer
+   blocked by `shfmt-py`'s release cadence. The cost is permanent maintenance
+   of a wheel matrix (linux x86_64/arm64, macOS x86_64/arm64) and a CI pipeline
+   that tracks upstream `shfmt` releases.
+
+2. **Native Go bindings to `shfmt`'s formatter API.** `shfmt` exposes its
+   formatter as a Go library. A binding via `gopy`/`cgo` would eliminate the
+   `subprocess` hop, give us in-process error handling, and remove the
+   `shfmt-py` dependency entirely. The cost is substantial: a new Go toolchain
+   in CI, a separate binding repository, and platform-specific build artefacts.
+   The performance win is also speculative — at typical Snakefile sizes (tens
+   of `shell:` directives), `subprocess` overhead is not a measured problem.
+
+3. **Keep `shfmt-py`.** No upfront work. We continue to consume upstream
+   `shfmt` via the existing wheel and accept that we are coupled to
+   `shfmt-py`'s release cadence and continued maintenance.
+
+## Decision
+
+**We continue to depend on `shfmt-py`.** No additional distribution work is
+undertaken until one of the revisit triggers below fires. The integration
+point in `snakefmt/shell_formatter.py` is structured so that swapping the
+backend later is a single-function change: `_invoke_shfmt` is the seam, and the
+masking logic that adapts Snakemake placeholders for shell parsers is shared
+across any future backend.
+
+## Consequences
+
+- `snakefmt` continues to inherit `shfmt-py`'s release cadence and platform
+  support matrix. As of writing, that means linux + macOS wheels, which matches
+  `snakefmt`'s CI matrix (`ubuntu-latest`, `macos-latest`).
+- We accept that `snakefmt` may lag upstream `shfmt` by one or more minor
+  versions. `shfmt`'s format output is stable across the 3.x series, so this
+  is not a correctness issue for the formatted output users will see.
+- The `subprocess` hop per `shell:` directive is preserved. At typical
+  Snakefile sizes this has not been observed to be a user-visible cost.
+- The shell-formatter call site is structured so that, if any of the revisit
+  triggers fires, the replacement work is contained to the implementation of
+  `_invoke_shfmt` (or its successor) in `snakefmt/shell_formatter.py`.
+
+## Revisit triggers
+
+This decision should be re-opened if any of the following occur:
+
+1. **A reported formatting bug is fixed in an upstream `shfmt` release**
+   that `shfmt-py` has not shipped within ~60 days of the upstream tag.
+2. **`shfmt-py` is unpublished from PyPI** or its source repository is
+   archived or marked deprecated.
+3. **A wheel for a platform `snakefmt` supports** (linux x86_64/arm64,
+   macOS x86_64/arm64) stops being published on a `shfmt-py` release.
+4. **`snakefmt` itself starts to depend on `shfmt` features** that are newer
+   than what `shfmt-py` ships — for example, surfacing a flag introduced in a
+   later upstream minor.
+
+### Non-triggers
+
+The following are explicitly *not* reasons to revisit this decision:
+
+- **`shfmt-py` is N minor versions behind upstream.** `shfmt`'s formatting
+  behaviour is stable across the 3.x line; version lag alone does not affect
+  users' formatted output. Only concrete bug fixes or feature needs (trigger 1
+  or 4 above) justify the maintenance cost of owning distribution.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+This directory contains records of significant architectural decisions made for `snakefmt`.

--- a/docs/plans/pr-295-heredoc-masking.md
+++ b/docs/plans/pr-295-heredoc-masking.md
@@ -1,0 +1,312 @@
+# PR #295: Heredoc body masking
+
+**PR:** [#295](https://github.com/snakemake/snakefmt/pull/295) — `feat!: format shell directives using shfmt`
+**Reviewer:** Hocnonsense, review `4294612620` on 2026-05-15
+**Status:** Plan drafted 2026-05-15
+
+## Problem
+
+The reviewer ran `snakefmt` on a real snakefile and hit:
+
+```
+snakefmt.exceptions.InvalidShell: Invalid shell code. shfmt error:
+<standard input>:18:16: unclosed here-document `!EOF!`
+```
+
+The offending shell block (excerpt):
+
+```
+shell:
+    """
+    ...
+    python <<!EOF!
+    \nif True:
+    ...
+    norm.to_csv(outfile, sep="\t")
+
+    \n!EOF!
+    """
+```
+
+The terminator line is `\n!EOF!`, not `!EOF!`. shfmt requires the terminator
+word to appear on its own line (column 0 for `<<DELIM`, leading tabs only for
+`<<-DELIM`). It doesn't match `\n!EOF!`, so shfmt declares the heredoc unclosed
+and aborts. snakefmt propagates this as `InvalidShell` and the entire file
+fails to format.
+
+The user's workaround today is `# fmt: off` around every shell block that uses
+this pattern — too brittle for real-world Snakemake codebases.
+
+The reviewer's other findings:
+
+- **Finding 2 — docstring indentation in non-shell directives.** Reviewer
+  marked out of scope. Confirmed: this is Black v26 docstring normalisation,
+  not anything our shfmt path touches. Defer.
+- **Finding 3 — "code should be formatted to run full tests".** Re-statement
+  of Finding 1 from a UX angle. Subsumed by the heredoc fix.
+
+## Why graceful degradation is the wrong fix
+
+The first instinct is "catch `InvalidShell`, log a warning, leave the block
+alone." This is what the reviewer was effectively doing manually with
+`# fmt: off`. It avoids the crash but doesn't help the user — their shell
+block still gets no formatting, and they still need to discover which blocks
+are problematic.
+
+The user explicitly pushed back on this: "I don't want to just throw up my
+hands and say, too hard!" — fix the actual case.
+
+## Root cause + fix
+
+### Key observation
+
+shfmt **does not reformat heredoc body content.** We already rely on this in
+`_indent_preserving_heredocs`, which only re-indents non-heredoc lines. So
+shfmt does not need to see the real heredoc body to do its job — it only
+needs to be able to *parse around it*.
+
+### Fix
+
+Pre-process the masked code, before shfmt runs: for each heredoc, detect the
+user-intended terminator (permissively, accepting snakemake-style escape
+prefixes like `\n!EOF!`) and replace the body + terminator with a
+placeholder body line + a clean terminator. shfmt parses happily, formats
+the surrounding code, and returns. After shfmt returns, splice the original
+body + terminator back in.
+
+```python
+# Updated pipeline:
+def format_shell_code(code: str) -> str:
+    masked, var_tokens, var_originals = _mask_snakemake_vars(code)
+    masked, heredoc_blocks = _mask_heredocs(masked)         # NEW
+    formatted = _invoke_shfmt(masked)
+    formatted = _unmask_heredocs(formatted, heredoc_blocks) # NEW
+    return _unmask_snakemake_vars(formatted, var_tokens, var_originals)
+```
+
+`_indent_preserving_heredocs` (called downstream by
+`format_python_string_literal`) is unchanged — it continues to handle
+post-shfmt indentation correctly.
+
+### Terminator-detection heuristic
+
+Walk forward from `<<DELIM`. The terminator is the **first** subsequent line
+where:
+
+1. The line ends with `DELIM` (followed only by optional trailing whitespace).
+2. Everything before `DELIM` on that line matches `^[\s]*(\\[a-z])*$` — i.e.,
+   the prefix consists only of whitespace, tabs, and backslash-escape
+   sequences like `\n`, `\t`.
+
+```python
+# Pseudocode
+def _looks_like_terminator(line: str, delim: str) -> bool:
+    stripped = line.rstrip()
+    if not stripped.endswith(delim):
+        return False
+    prefix = stripped[: -len(delim)]
+    return re.fullmatch(r"[\s]*(\\[a-z])*", prefix) is not None
+```
+
+Cases this catches (✓) vs ignores (✗):
+
+| Body line | Terminator? | Why |
+|-----------|-------------|-----|
+| `EOF` | ✓ | Standard |
+| `\tEOF` | ✓ | `<<-EOF` form |
+| `    EOF` | ✓ | Leading whitespace before our re-indent runs |
+| `\n!EOF!` | ✓ | Snakemake escape prefix |
+| `\n\n!EOF!` | ✓ | Multiple escapes |
+| `prefix_EOF` | ✗ | DELIM not preceded by whitespace/escape |
+| `EOF more text` | ✗ | DELIM not at end of line |
+| `# EOF` | ✗ | `#` is not a recognised escape prefix |
+
+### Mask + restore mechanics
+
+```python
+_HEREDOC_TOKEN_FMT = "__SNAKEFMT_HEREDOC_{nonce}_{idx}__"
+
+def _mask_heredocs(code: str) -> tuple[str, tuple[tuple[str, str], ...]]:
+    """Replace heredoc body+terminator with a placeholder body + clean terminator
+    line so shfmt can parse the surrounding shell.
+
+    Returns (masked_code, blocks) where blocks[i] is (token, original_block_text).
+    """
+    nonce = uuid.uuid4().hex
+    out_lines: list[str] = []
+    blocks: list[tuple[str, str]] = []
+    lines = code.splitlines(keepends=True)
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = _HEREDOC_START.search(line)
+        if not m:
+            out_lines.append(line)
+            i += 1
+            continue
+
+        delim = m.group(1)
+        out_lines.append(line)  # keep the <<DELIM command line
+        i += 1
+
+        # Walk forward for the terminator.
+        body_start = i
+        terminator_idx: int | None = None
+        while i < len(lines):
+            if _looks_like_terminator(lines[i], delim):
+                terminator_idx = i
+                break
+            i += 1
+
+        if terminator_idx is None:
+            # No terminator found — leave the rest as-is; shfmt will error
+            # with the genuine "unclosed here-document" message.
+            out_lines.extend(lines[body_start:])
+            return "".join(out_lines), tuple(blocks)
+
+        original_block = "".join(lines[body_start : terminator_idx + 1])
+        token = _HEREDOC_TOKEN_FMT.format(nonce=nonce, idx=len(blocks))
+        blocks.append((token, original_block))
+
+        # Insert: placeholder body line containing the token, then a clean
+        # terminator at column 0.
+        out_lines.append(token + "\n")
+        out_lines.append(delim + "\n")
+        i = terminator_idx + 1
+
+    return "".join(out_lines), tuple(blocks)
+
+
+def _unmask_heredocs(code: str, blocks: tuple[tuple[str, str], ...]) -> str:
+    """Restore heredoc bodies + terminators, undoing _mask_heredocs."""
+    for token, original in blocks:
+        # Replace the token line + the next line (clean terminator) with
+        # the original body+terminator block.
+        marker = re.compile(re.escape(token) + r".*\n.*\n", re.DOTALL)
+        code = marker.sub(lambda _m: original, code, count=1)
+    return code
+```
+
+UUID nonce + indexed token guarantees uniqueness across calls and immunity
+from collision with literal user content (same pattern as
+`_mask_snakemake_vars`).
+
+## Cases the fix handles
+
+1. **The reviewer's exact case** — `python <<!EOF!` with `\n!EOF!` terminator
+   → masked, formatted, restored verbatim.
+2. **Standard heredocs** (`<<EOF`, `<<-EOF`, `<<'EOF'`) — terminator detected,
+   body preserved, behaviour identical to today.
+3. **Multiple heredocs in one shell block** — each masked independently with
+   distinct token indices; restored in order.
+4. **Heredoc body that looks like reformattable shell** — body never touched
+   by shfmt because shfmt sees only the placeholder.
+5. **Surrounding shell still gets formatted** — masking only the body +
+   terminator, not the `<<DELIM` line, leaves shfmt free to reformat the
+   pipeline around the heredoc.
+
+## Cases NOT handled (intentional)
+
+1. **Truly unclosed heredoc** (no terminator-like line anywhere in the rest
+   of the block) — `_mask_heredocs` falls through, shfmt receives the
+   original input, raises `InvalidShell` as before. This is genuine bash
+   error, not snakefmt's job to paper over.
+2. **DELIM appearing as substring inside legitimate body content with
+   whitespace prefix** (e.g., body line ` EOF ` where the user *meant* it as
+   data, not a terminator) — heuristic will detect it as the terminator.
+   Vanishingly rare in real heredocs; documented as a known limitation.
+
+## Tests to add
+
+In `tests/test_shell_formatter.py`:
+
+```python
+def test_format_shell_code_heredoc_with_snakemake_escape_terminator():
+    """Reviewer's exact case: \\n!EOF! is detected as the user-intended
+    terminator and masked, even though shfmt alone would fail on it."""
+    code = (
+        "python <<!EOF!\n"
+        "\\nif True:\n"
+        "    pass\n"
+        "\n"
+        "\\n!EOF!\n"
+    )
+    # Round-trips verbatim — body and terminator restored exactly.
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_heredoc_body_never_reformatted():
+    """Body content that looks like reformattable shell stays untouched."""
+    code = (
+        "cat <<EOF\n"
+        "if true\nthen\necho yes\nfi\n"  # NOT formatted by shfmt
+        "EOF\n"
+    )
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_multiple_heredocs():
+    """Two heredocs in the same block round-trip independently."""
+    code = (
+        "cat <<EOF\nbody1\nEOF\n"
+        "cat <<END\nbody2\nEND\n"
+    )
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_heredoc_surrounded_by_formatted_shell():
+    """Shell around the heredoc gets formatted; heredoc body stays verbatim."""
+    unformatted = (
+        "if true\nthen\n"
+        "cat <<EOF\nbody\nEOF\n"
+        "fi\n"
+    )
+    expected = (
+        "if true; then\n"
+        "    cat <<EOF\nbody\nEOF\n"
+        "fi\n"
+    )
+    assert format_shell_code(unformatted) == expected
+
+
+def test_format_shell_code_truly_unclosed_heredoc_raises():
+    """No terminator candidate → shfmt sees the original, raises InvalidShell."""
+    code = "cat <<EOF\nbody with no terminator anywhere\n"
+    with pytest.raises(InvalidShell):
+        format_shell_code(code)
+```
+
+Existing tests in `TestIndentPreservingHeredocs` and
+`TestFormatPythonStringLiteralHeredocs` continue to pass — `_mask_heredocs`
+runs upstream of `_indent_preserving_heredocs` and doesn't change its
+contract.
+
+## README addendum
+
+Update the "Snakemake placeholders" / "Invalid shell" subsection of the
+shell-formatting section: snakefmt now masks heredoc bodies before invoking
+shfmt, so heredocs that use snakemake-style escape prefixes on their
+terminator (e.g., `\n!EOF!`) format successfully without `# fmt: off`.
+Heredoc body content is never reformatted (matches shfmt's own behaviour).
+
+## Execution order
+
+1. Add `_HEREDOC_TOKEN_FMT`, `_looks_like_terminator`, `_mask_heredocs`,
+   `_unmask_heredocs` to `snakefmt/shell_formatter.py`.
+2. Wire them into `format_shell_code`.
+3. Add the five new tests in `tests/test_shell_formatter.py`.
+4. Run snakefmt against the reviewer's exact snakefile snippet (smoke test)
+   — verify it formats without `# fmt: off`.
+5. Update README "Invalid shell" subsection.
+6. Validate: `make fmt && make lint && uv run pytest -q`.
+7. Commit (one focused commit) + push.
+
+## Out of scope
+
+- **Finding 2 (docstring indentation in non-shell rules)** — Black v26
+  behaviour, not snakefmt; reviewer marked out of scope.
+- **Graceful degradation fallback** — explicitly rejected by the user; we
+  fix the actual case rather than mask the symptom.
+- **CLI flag for strict-vs-warn behaviour** — not needed; the fix is
+  transparent.

--- a/docs/plans/pr-295-review-response.md
+++ b/docs/plans/pr-295-review-response.md
@@ -1,0 +1,242 @@
+# PR #295 Review Response Plan
+
+**PR:** [#295](https://github.com/snakemake/snakefmt/pull/295) — `feat!: format shell directives using shfmt`
+**Reviewers:** Hocnonsense (CHANGES_REQUESTED), CodeRabbit (auto)
+**Status:** Plan drafted 2026-05-14
+
+## Reviewer Findings
+
+### Already addressed (CodeRabbit)
+
+- **Mask token UUID nonce** — fixed in commit `f261ae3`. Per-call nonce eliminates collision risk between mask tokens and literal user text.
+- **Pattern tightening** (`{...}` regex too permissive) — declined. Tightening to disallow `[`, `:`, `.` would break valid Snakemake syntax like `{input[0]}`, `{threads:02d}`, `{wildcards.sample}`. The negative lookahead/lookbehind (`(?<!\{)`, `(?!\})`) plus the leading character class `[a-zA-Z0-9_]` give sufficient guard against shell function bodies (`fn() { … }`) since those don't start with an identifier character immediately after `{`.
+
+### To fix in this PR
+
+#### B2 — Heredoc indentation breakage (correctness, blocker)
+
+**Source:** Hocnonsense, `snakefmt/shell_formatter.py:105`.
+
+`textwrap.indent` prepends `used_indent` to **every line** of the shfmt output. This corrupts heredocs:
+
+- `<<EOF` requires the terminator at column 0 → after indent, bash never closes the heredoc.
+- `<<-EOF` strips only leading **tabs**, not spaces → space-indent still breaks the terminator.
+- Body content inside the heredoc (e.g. embedded Python) has semantically-significant indentation that uniform space-padding corrupts.
+
+**Fix:** heredoc-aware indent. After shfmt produces output, parse for heredoc start markers and skip indenting body + terminator lines.
+
+```python
+_HEREDOC_START = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?")
+
+def _indent_preserving_heredocs(text: str, indent: str) -> str:
+    """Indent each line by `indent` except inside heredoc bodies, where the
+    terminator must remain at column 0 (or leading tabs only for <<-)."""
+    out_lines: list[str] = []
+    in_heredoc: str | None = None  # terminator word when inside
+    for line in text.splitlines(keepends=True):
+        stripped_for_term = line.rstrip("\n")
+        if in_heredoc is not None:
+            out_lines.append(line)  # never indent body lines
+            if stripped_for_term == in_heredoc or stripped_for_term.lstrip("\t") == in_heredoc:
+                in_heredoc = None
+            continue
+        out_lines.append(indent + line if line.strip() else line)
+        m = _HEREDOC_START.search(line)
+        if m:
+            in_heredoc = m.group(1)
+    return "".join(out_lines)
+```
+
+Replaces the single `textwrap.indent(formatted_content, used_indent)` call.
+
+shfmt is already heredoc-aware: it does not reformat heredoc bodies. So the only contribution snakefmt needs to make is to not destroy them on the way out.
+
+**Edge cases to handle:**
+- Quoted terminator: `<<'EOF'` and `<<"EOF"` — same terminator word, just no shell-expansion in body.
+- `<<-EOF` (dash) — terminator may have leading tabs.
+- Multiple heredocs on one line (rare but legal): `cmd <<EOF1 <<EOF2`. Punt on this; document as known limitation.
+- Quoted text containing `<<word` inside `'...'` or `"..."` — must not trigger heredoc mode. The simple regex above will misfire; either accept this as a rare case or use a more careful tokenizer. **Decision:** accept for v1, add a test that documents the false-positive corner case.
+
+#### C1 — Mask `{{...}}` to preserve brace count and Snakemake/bash semantics (correctness, blocker)
+
+**Source:** Hocnonsense comments #3, #6, #8b.
+
+**Problem:** `{{...}}` in source must round-trip verbatim through shfmt because:
+
+1. **Snakemake `str.format()` brace counting:** Snakemake renders shell strings via `str.format()`, which only accepts `{{` → `{` and `}}` → `}` as escape pairs. If shfmt ever splits `{{` into `{ {` while wrapping (e.g. when reformatting a brace group), post-render raises `ValueError: Single '{' encountered in format string`.
+2. **Plain-string brace expansion** (#8b): `cp tmp/{{a,b}} output/` represents `cp tmp/{a,b} output/` to the shell. shfmt formatting `{{a,b}}` directly may differ from how it would format `{a,b}`.
+3. **F-string Snakemake variables** (#3, #6): In an f-string, `{{output}}` is the actual Snakemake variable (Python collapses `{{}}` → `{}`, then Snakemake substitutes). Currently NOT masked, so shfmt sees `{{output}}` literally and may reformat in ways that break post-Python brace counting.
+
+**Decision: mask all `{{...}}` patterns** uniformly across plain strings and f-strings. The formatter does not need to model runtime semantics — it preserves every brace-bracketed token verbatim.
+
+**Trade-off (accepted):** bash brace groups `{{ cmd1; cmd2; }}` lose internal formatting because shfmt sees only an opaque token. This case is rare in Snakemake shell directives (`&&` chains and line continuations cover most pipelines). Users who need brace-group formatting can use `# fmt: off`.
+
+**Cases preserved correctly under this policy:**
+
+| Case | Source | Bash sees | Round-trip |
+|------|--------|-----------|------------|
+| Brace group | `{{ echo hi; }}` | `{ echo hi; }` | ✓ verbatim, no internal formatting |
+| Parameter expansion | `${{VAR}}` | `${VAR}` | ✓ shfmt sees `$TOKEN`, restored to `${{VAR}}` |
+| Brace expansion | `cp f{{1,2}}.txt` | `cp f{1,2}.txt` | ✓ token preserved |
+| awk/sed in quotes | `awk '{{print $1}}'` | `awk '{print $1}'` | ✓ no-op (shfmt doesn't reformat quoted content) |
+| F-string Snakemake var | `f"echo {{output}}"` | substituted path | ✓ token preserved |
+
+Implementation outline:
+
+```python
+_DOUBLE_BRACE_PATTERN = re.compile(r"\{\{[^{}]*\}\}")
+_SINGLE_BRACE_PATTERN = re.compile(r"(?<!\{)\{([a-zA-Z0-9_][^{}]*)\}(?!\})")
+
+def _mask_snakemake_vars(code: str) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    nonce = uuid.uuid4().hex
+    tokens: list[str] = []
+    originals: list[str] = []
+
+    def replace(match: re.Match[str]) -> str:
+        token = f"__SNAKEFMT_{nonce}_{len(tokens)}__"
+        tokens.append(token)
+        originals.append(match.group(0))
+        return token
+
+    # Mask {{...}} FIRST so the lookbehind/lookahead on the single-brace
+    # pattern doesn't get confused by partial matches.
+    code = _DOUBLE_BRACE_PATTERN.sub(replace, code)
+    code = _SINGLE_BRACE_PATTERN.sub(replace, code)
+    return code, tuple(tokens), tuple(originals)
+```
+
+`_unmask_snakemake_vars` already does the right thing — iterates `(token, original)` pairs in reverse and substitutes. No signature change.
+
+**F-string handling:** with this fix, f-strings are formatted normally. No special-case skip. The reviewer's underlying concern (wrong masking semantics for f-strings) is resolved by the unified two-layer mask.
+
+#### C2 — Mask token line-length impact (verification)
+
+**Source:** Hocnonsense comment #8a.
+
+**Concern:** The mask token `__SNAKEFMT_<32hex>_<n>__` is ~50 chars. shfmt may make formatting decisions based on token-inflated line lengths, producing output that doesn't reflect real lengths post-unmask.
+
+**Verification:** shfmt does NOT do length-based line wrapping by default. The `-i 4 -ci -bn` flags we use are syntactic only. So this should be a non-issue.
+
+**Action:** add a test that places multiple `{var}` tokens on a single long line and asserts no spurious line breaks are introduced. Pre-existing `test_format_shell_code_many_variables` already covers token uniqueness; new test extends to length-based check.
+
+```python
+def test_format_shell_code_long_line_no_spurious_wrap():
+    vars = " ".join(f"{{var{i}}}" for i in range(10))
+    unformatted = f"echo {vars}\n"
+    expected = unformatted
+    assert format_shell_code(unformatted) == expected
+```
+
+If shfmt does wrap (unexpected), pivot to a flag that disables length wrap, with a follow-up note.
+
+Reviewer's secondary suggestion (test that asserts UUID is not in code post-unmask): redundant with existing tests — if any token survived, the round-trip would visibly differ from the original. Skip.
+
+#### M1 — `Snakefile.format_shell` set imperatively from CLI (maintainability)
+
+**Source:** Hocnonsense comment #2 (`snakefmt/snakefmt.py:264`).
+
+Currently:
+
+```python
+snakefile.format_shell = format_shell  # imperative, post-construction mutation
+```
+
+Move `format_shell` into the constructor signature, mirroring `sort_directives`. Pass through from CLI to `Formatter.__init__` (or `Parser.__init__`).
+
+Steps:
+1. Find where `sort_directives` flows from CLI → constructor. Mirror that path.
+2. Update `snakefmt.py` `main` to pass `format_shell=format_shell` to the constructor.
+3. Remove the imperative assignment.
+4. Verify `tests/test_config.py::TestShellFormattingConfig` and `tests/test_formatter.py::TestShellBlockFormatting` still pass.
+
+#### S1 — Regex consolidation (style)
+
+**Source:** Hocnonsense comment #5 (`shell_formatter.py:89`).
+
+Combine the two `re.fullmatch` calls in `format_python_string_literal`:
+
+```python
+match = re.fullmatch(r'^([a-zA-Z]*)("""|\'\'\'')([\s\S]*?)(\2)$', literal)
+```
+
+Backreference `\2` ensures the closing quote matches the opening one. No semantic change.
+
+#### S2 — Docstring gap on no-op fallback (style)
+
+**Source:** Hocnonsense comment #5 (second half).
+
+`format_python_string_literal` silently returns the input unchanged on non-match. Document this in the docstring, and explicitly note that the function expects the literal to come from `str(parameter)` (caller-side guarantees no leading whitespace beyond the trailing-rstrip handled internally).
+
+#### T1 — More edge-case tests (test coverage)
+
+**Source:** Hocnonsense comment #7, plus the trade-offs locked in by C1.
+
+Add to `TestShellBlockFormatting` (or a dedicated `TestShellHeredocs` class):
+
+1. **Indent variants** — too few / too many leading spaces in source, formatted result still has consistent target indent.
+2. **Basic heredoc** — `<<EOF` terminator lands at column 0 after formatting (covers B2).
+3. **Indented heredoc** — `<<-EOF` body and terminator preserved correctly.
+4. **Quoted heredoc** — `<<'EOF'` (terminator quoted) preserved.
+5. **Heredoc with embedded `\n` and blank lines** — e.g. embedded Python heredoc preserves significant indentation.
+6. **Parameter expansion `${{VAR}}`** — round-trips verbatim (most common case-2 idiom).
+7. **Brace group `{{ echo hi; echo bye; }}`** — preserved verbatim but NOT internally reformatted (locks in the C1 trade-off so future contributors don't try to "fix" it without understanding).
+8. **Brace expansion `{{a,b,c}}`** — preserved verbatim.
+9. **F-string with `{{output}}`** — round-trips, exercising the new f-string handling.
+
+```python
+def test_heredoc_terminator_at_column_zero(self):
+    snakefile = dedent('''\
+        rule a:
+            shell:
+                """
+                cat <<EOF
+                line1
+                EOF
+                """
+        ''')
+    formatted = formatter(snakefile)
+    assert "\nEOF\n" in formatted  # terminator at column 0 after the newline before
+```
+
+```python
+def test_format_shell_code_param_expansion_round_trips():
+    code = 'echo ${{VAR}} ${{VAR:-default}}\n'
+    assert format_shell_code(code) == code
+
+def test_format_shell_code_brace_group_preserved_not_internally_formatted():
+    code = '{{ echo hi; echo bye; }}\n'
+    # Token-masked, restored verbatim. Body not internally reformatted.
+    assert format_shell_code(code) == code
+```
+
+## README addendum
+
+Add a short note to the shell-formatting section:
+
+> **Limitation**: bash brace groups (`{{ cmd1; cmd2; }}` in Snakefile source, `{ cmd1; cmd2; }` in bash) are preserved verbatim but their bodies are not internally reformatted by shfmt. This is intentional — the brace count must be preserved exactly so Snakemake's `str.format()` render step doesn't break. If you need internal formatting for a brace group, wrap the block in `# fmt: off` / `# fmt: on`.
+
+## Execution Order
+
+1. **C1** — unified two-layer mask (`{{...}}` + `{...}`). Smallest correctness fix. Adds test coverage for `{{...}}` round-trip and f-string formatting.
+2. **B2** — heredoc-aware indent. Largest change. Adds `_indent_preserving_heredocs` helper.
+3. **T1** — heredoc + edge-case tests, proves B2 + C1.
+4. **C2** — long-line mask token verification test.
+5. **M1** — constructor plumbing refactor.
+6. **S1, S2** — regex consolidation + docstring cleanup.
+7. **README addendum** — limitation note.
+
+Each step ends with **`make fmt && make lint && uv run pytest -q`** to confirm green before moving to the next. Suggested commit grouping (so the PR diff stays reviewable):
+
+- Commit 1: C1 + matching tests in `tests/test_shell_formatter.py`.
+- Commit 2: B2 + heredoc tests (T1 subset).
+- Commit 3: T1 remaining edge-case tests + C2.
+- Commit 4: M1 refactor.
+- Commit 5: S1 + S2 + README addendum.
+
+## Out of Scope
+
+- **Pattern tightening** — declined; would break valid Snakemake placeholders.
+- **F-string skip** — initial recommendation revised; unified mask handles f-strings correctly.
+- **Brace-group internal formatting** — accepted limitation, escape hatch via `# fmt: off`.
+- **Multi-heredoc on one line** — accept as known limitation, document with test.
+- **Heredoc detection inside quoted strings** — accept false-positive case, document.

--- a/docs/plans/shell-formatting-trailing-newline-bugfix.md
+++ b/docs/plans/shell-formatting-trailing-newline-bugfix.md
@@ -1,0 +1,133 @@
+# Plan: Fix trailing-newline bug in shell formatting
+
+- **Date:** 2026-05-13
+- **Branch:** `feat/shfmt`
+- **Related:** ADR-0001 (shell-formatter distribution), GitHub issue #170
+
+## 1. Diagnosis
+
+Root cause: `format_python_string_literal` in `snakefmt/shell_formatter.py`
+uses `re.fullmatch(r'^([a-zA-Z]*)(""")([\s\S]*?)(\2)$', literal)`, which
+requires the literal to end **exactly** at the closing `"""`. The caller at
+`snakefmt/formatter.py:407` builds `val = str(parameter)`, and the parser
+emits a `NEWLINE` token after the closing triple-quote, so the literal that
+arrives at the helper looks like `'"""...\n        """\n'`.
+
+The regex `fullmatch` rejects this (trailing `\n` not consumed by `$`), the
+helper returns its input unchanged, and shell formatting becomes a silent
+end-to-end no-op in real `snakefmt` runs.
+
+Unit tests in `tests/test_shell_formatter.py` pass because they hand-build
+literals **without** the trailing newline. The integration test gap is the
+reason the bug shipped.
+
+Evidence (traced 2026-05-13):
+
+```text
+IN  startswith """: True endswith """: False len: 210
+IN repr: '"""\n        bwa mem ...\n        """\n'
+CHANGED: False
+```
+
+With `literal.rstrip()` applied before regex match, formatting fires
+correctly.
+
+## 2. TDD red — write failing tests first
+
+### 2a. Helper robustness suite
+
+Location: `tests/test_shell_formatter.py`.
+
+One parametrized test asserting `format_python_string_literal` reformats its
+content (i.e., does **not** return its input unchanged) for each of these
+input shapes:
+
+1. Trailing `\n` after closing `"""` — the actual bug.
+2. Multiple trailing newlines (`\n\n`).
+3. Trailing spaces / tabs after closing `"""`.
+4. `\r\n` line endings inside the literal.
+5. String prefix variants: `f"""`, `rb"""`, `B"""`, `u"""`, and bare `"""`.
+
+### 2b. End-to-end behavioural set
+
+Location: `tests/test_formatter.py`, new `TestShellBlockFormatting` class
+(or equivalent). All cases drive a Snakefile through the public formatter
+(`setup_formatter`) and assert on the rendered output.
+
+1. **Default-on formats.** Snakefile with messy `shell:` block in; shfmt-
+   formatted shell content out; no flags touched.
+2. **`format_shell = False` disables.** Same Snakefile input; attribute set
+   `False`; shell content rendered unchanged from input.
+3. **Config-driven disable.** `format_shell = false` in TOML config exercises
+   the CLI plumbing path. Probably lives in `tests/test_config.py` or
+   `tests/test_main.py`.
+4. **`{var}` masking preserved end-to-end.** Snakefile body contains
+   `{input}`, `{output}`, and escaped `{{print $1}}`. Assert all three
+   survive parser → formatter → shfmt round-trip verbatim.
+5. **`# fmt: off` opts out of shell formatting.** Shell block wrapped
+   between `# fmt: off` / `# fmt: on`; content untouched.
+
+All new tests **must fail (RED)** before the fix is applied — confirms the
+bug and prevents the fix from being a vacuous green.
+
+## 3. Fix
+
+Single edit in `snakefmt/shell_formatter.py`:
+
+```python
+def format_python_string_literal(literal: str, target_indent: int = 0) -> str:
+    literal = literal.rstrip()  # NEW: tolerate trailing whitespace from parser
+    match = re.fullmatch(r'^([a-zA-Z]*)(""")([\s\S]*?)(\2)$', literal)
+    ...
+```
+
+The caller already `rstrip`s `val` at `formatter.py:418`, so trailing
+whitespace was always going to be discarded — stripping it earlier inside the
+helper just lets the regex see a parseable shape. No behavioural change
+downstream.
+
+## 4. Triage existing test breakage — per-test (option P)
+
+Run `uv run pytest`. For every test in `tests/test_formatter.py` that breaks
+after the fix:
+
+- **Test is about shell formatting itself** (assertions reference shell body
+  shape, indentation, line wrapping inside `shell:`) → update the expected
+  string to reflect shfmt's output. The old expectation was a fossil of the
+  bug.
+- **Test is about something else** (directive sorting, comment placement,
+  indentation outside the shell block, etc.) and the shell content is
+  incidental → add `snakefile.format_shell = False` to preserve the test's
+  original intent. Pattern already exists at `tests/test_formatter.py:868,
+  900, 918`.
+
+Document the per-test decisions in the commit message so a reviewer can
+trace why each expected string changed.
+
+## 5. Verify
+
+- `uv run pytest` — all existing + new tests green.
+- Manual smoke: run `snakefmt` on a sample Snakefile with a messy `shell:`
+  block; confirm reformatting fires end-to-end.
+
+## 6. Explicit non-goals
+
+- No regex rewrite — `rstrip` is sufficient.
+- No new shfmt flags.
+- No performance / caching work.
+- No fixes to `format_python_string_literal`'s indentation handling beyond
+  what the bug demands.
+- No changes to the seam structure introduced in the earlier refactor
+  (`_mask_snakemake_vars`, `_invoke_shfmt`, `_unmask_snakemake_vars`).
+
+## 7. Risks and open questions
+
+- **Unknown count of broken existing tests.** Cannot pre-count without
+  running pytest after the fix. If the count is large (>20), reconsider
+  option Q (blanket opt-out in `setup_formatter` default) — but only after
+  seeing the actual breakage shape.
+- **`# fmt: off` interaction is unverified.** Test 2b.5 will resolve this;
+  if it fails, a separate fix may be needed.
+- **Config-path test (2b.3) location.** Will be decided at implementation
+  time depending on what `tests/test_config.py` and `tests/test_main.py`
+  already cover.

--- a/lua/snakefmt/config.lua
+++ b/lua/snakefmt/config.lua
@@ -2,6 +2,7 @@ local M = {}
 M.defaults = {
   auto_format = false,
   line_length = nil,
+  format_shell = nil,
   bin_path = nil,
   uvx_fallback = true,
 }

--- a/lua/snakefmt/init.lua
+++ b/lua/snakefmt/init.lua
@@ -50,6 +50,9 @@ function M.format(sync)
     table.insert(full_cmd, "--line-length")
     table.insert(full_cmd, tostring(config.options.line_length))
   end
+  if config.options.format_shell == false then
+    table.insert(full_cmd, "--no-format-shell")
+  end
   table.insert(full_cmd, "-")
 
   if sync then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ keywords = [
 dependencies = [
     "click>=8.2.0,<9",
     "black>=26.3.1,<27",
+    "shfmt-py>=3.12.0.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
 dependencies = [
     "click>=8.2.0,<9",
     "black>=26.3.1,<27",
-    "shfmt-py>=3.12.0.2",
+    "shfmt-py>=4.0.0,<5.0.0",
 ]
 
 [project.urls]

--- a/snakefmt/exceptions.py
+++ b/snakefmt/exceptions.py
@@ -56,3 +56,7 @@ class InvalidBlackConfiguration(Exception):
 
 class MalformattedToml(Exception):
     pass
+
+
+class InvalidShell(Exception):
+    pass

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -21,6 +21,7 @@ from snakefmt.parser.syntax import (
     Syntax,
     split_code_string,
 )
+from snakefmt.shell_formatter import format_python_string_literal
 from snakefmt.types import TAB
 
 TAB_SIZE = len(TAB)
@@ -398,11 +399,15 @@ class Formatter(Parser):
         target_indent: int,
         inline_formatting: bool,
         param_list: bool = True,
+        keyword_name: str = "",
     ) -> str:
         string_indent = TAB * target_indent
         if inline_formatting:
             target_indent = 0
         val = str(parameter)
+
+        if keyword_name == "shell" and getattr(self.snakefile, "format_shell", True):
+            val = format_python_string_literal(val, target_indent)
 
         try:
             # A snakemake parameter is syntactically like a function parameter
@@ -490,7 +495,7 @@ class Formatter(Parser):
             # here, check if the value is too large to put in one line
             param = parameters.all_params[0]
             param_result = self.format_param(
-                param, target_indent, inline_fmting, param_list
+                param, target_indent, inline_fmting, param_list, parameters.keyword_name
             )
             inline_fmting = param_result.count("\n") == 1
         if inline_fmting:
@@ -507,8 +512,13 @@ class Formatter(Parser):
             result = f"{result}{parameters.comment}\n"
             for param in parameters.all_params:
                 result += self.format_param(
-                    param, target_indent, inline_fmting, param_list
+                    param,
+                    target_indent,
+                    inline_fmting,
+                    param_list,
+                    parameters.keyword_name,
                 )
+
         num_c = len(param.post_comments)
         if num_c > 1 or (not param._has_inline_comment and num_c == 1):
             Warnings.block_comment_below(parameters.keyword_name, keyword_line_nb)

--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -62,6 +62,7 @@ class Formatter(Parser):
         line_length: Optional[int] = None,
         sort_directives: bool = False,
         black_config_file: Optional[PathLike] = None,
+        format_shell: bool = False,
     ):
         self.result: str = ""
         self.lagging_comments: str = ""
@@ -71,6 +72,7 @@ class Formatter(Parser):
         self.keywords: dict[str, str] = {}  # cache to sort
 
         self.black_mode = read_black_config(black_config_file)
+        self.format_shell = format_shell
 
         if line_length is not None:
             self.black_mode.line_length = line_length
@@ -406,7 +408,7 @@ class Formatter(Parser):
             target_indent = 0
         val = str(parameter)
 
-        if keyword_name == "shell" and getattr(self.snakefile, "format_shell", True):
+        if keyword_name == "shell" and self.format_shell:
             val = format_python_string_literal(val, target_indent)
 
         try:

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -191,11 +191,12 @@ def format_python_string_literal(literal: str, target_indent: int = 0) -> str:
     # Strip trailing whitespace: the parser appends a NEWLINE token after the
     # closing triple-quote, so the literal arrives as '"""..."""\n'. The caller
     # already rstrips the result, so this is safe.
-    literal = literal.rstrip()
-    match = _TRIPLE_QUOTE_RE.fullmatch(literal)
+    # rstrip only for matching/processing; non-matching literals are returned verbatim.
+    original = literal
+    match = _TRIPLE_QUOTE_RE.fullmatch(literal.rstrip())
 
     if not match:
-        return literal  # not a triple-quoted string literal; return unchanged
+        return original  # not a triple-quoted string literal; return unchanged
 
     prefix = match.group(1)
     quote = match.group(2)

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 import textwrap
+import uuid
 
 from snakefmt.exceptions import InvalidShell
 
@@ -10,28 +11,44 @@ TAB = "    "
 # passes through to the shell verbatim, e.g. `awk '{{print $1}}'`).
 # The leading character class avoids matching shell function bodies like
 # `foo() { echo bar }`.
+# Intentionally permissive beyond the first character: in Snakemake shell
+# blocks, ALL single {…} are Snakemake expressions by definition — literal
+# braces must use {{…}}. This correctly captures {input[0]}, {threads:02d},
+# {wildcards.sample}, etc.
 _SNAKEMAKE_VAR_PATTERN = re.compile(r"(?<!\{)\{([a-zA-Z0-9_][^{}]*)\}(?!\})")
 
-_MASK_TEMPLATE = "__SNAKEFMT_VAR_{}__"
 
+def _mask_snakemake_vars(code: str) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Replace Snakemake `{var}` placeholders with opaque tokens shfmt won't touch.
 
-def _mask_snakemake_vars(code: str) -> tuple[str, tuple[str, ...]]:
-    """Replace Snakemake `{var}` placeholders with opaque tokens shfmt won't touch."""
+    Uses a per-call UUID nonce in the token to eliminate any risk of collision
+    with literal text that happens to look like a mask token.
+
+    Returns (masked_code, tokens, originals) — tokens[i] is the exact string
+    inserted for originals[i], so _unmask_snakemake_vars can replace by value
+    rather than by reconstructing the template.
+    """
+    nonce = uuid.uuid4().hex
+    tokens: list[str] = []
     originals: list[str] = []
 
     def replace(match: re.Match[str]) -> str:
+        token = f"__SNAKEFMT_{nonce}_{len(tokens)}__"
+        tokens.append(token)
         originals.append(match.group(0))
-        return _MASK_TEMPLATE.format(len(originals) - 1)
+        return token
 
     masked = _SNAKEMAKE_VAR_PATTERN.sub(replace, code)
-    return masked, tuple(originals)
+    return masked, tuple(tokens), tuple(originals)
 
 
-def _unmask_snakemake_vars(code: str, originals: tuple[str, ...]) -> str:
-    """Reverse of `_mask_snakemake_vars`. Walks tokens in reverse to avoid
-    substring collisions between e.g. `__SNAKEFMT_VAR_1__` and `__SNAKEFMT_VAR_10__`."""
-    for i in range(len(originals) - 1, -1, -1):
-        code = code.replace(_MASK_TEMPLATE.format(i), originals[i])
+def _unmask_snakemake_vars(
+    code: str, tokens: tuple[str, ...], originals: tuple[str, ...]
+) -> str:
+    """Reverse of `_mask_snakemake_vars`. Replaces each token by its stored
+    string value rather than re-constructing from a template."""
+    for token, original in zip(reversed(tokens), reversed(originals)):
+        code = code.replace(token, original)
     return code
 
 
@@ -53,9 +70,9 @@ def _invoke_shfmt(code: str) -> str:
 
 def format_shell_code(code: str) -> str:
     """Format shell code using shfmt, preserving Snakemake `{var}` placeholders."""
-    masked, originals = _mask_snakemake_vars(code)
+    masked, tokens, originals = _mask_snakemake_vars(code)
     formatted = _invoke_shfmt(masked)
-    return _unmask_snakemake_vars(formatted, originals)
+    return _unmask_snakemake_vars(formatted, tokens, originals)
 
 
 def format_python_string_literal(literal: str, target_indent: int = 0) -> str:

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -9,7 +9,7 @@ TAB = "    "
 # Matches `{{...}}` escaped brace pairs — these encode literal shell `{...}` after
 # Snakemake's str.format() render. Masked FIRST so the single-brace pattern doesn't
 # partially match their inner content. Pattern: any content without nested braces.
-_DOUBLE_BRACE_PATTERN = re.compile(r"\{\{[^{}]*\}\}")
+_DOUBLE_BRACE_PATTERN = re.compile(r"\{\{.*?\}\}", flags=re.DOTALL)
 
 # Matches single `{var}` Snakemake placeholders. The leading character class avoids
 # matching shell function bodies like `foo() { echo bar }`. The negative
@@ -81,7 +81,7 @@ def format_shell_code(code: str) -> str:
     return _unmask_snakemake_vars(formatted, tokens, originals)
 
 
-_HEREDOC_START = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?")
+_HEREDOC_START = re.compile(r"<<-?\s*['\"]?([^'\"\s<>|;&()]+)['\"]?")
 
 # Matches any Python triple-quoted string literal, with or without a prefix (f, r, b,
 # etc.). Uses `"{3}|'{3}` so the closing backreference \2 matches the same quote style

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -70,7 +70,7 @@ def _invoke_shfmt(code: str) -> str:
             check=True,
         )
     except subprocess.CalledProcessError as e:
-        raise InvalidShell(f"Invalid shell code. shfmt error: {e.stderr}")
+        raise InvalidShell(f"Invalid shell code. shfmt error: {e.stderr}") from e
     return process.stdout
 
 

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -74,11 +74,78 @@ def _invoke_shfmt(code: str) -> str:
     return process.stdout
 
 
+_HEREDOC_TOKEN_FMT = "__SNAKEFMT_HEREDOC_{nonce}_{idx}__"
+
+
+def _looks_like_terminator(line: str, delim: str) -> bool:
+    stripped = line.rstrip()
+    if not stripped.endswith(delim):
+        return False
+    prefix = stripped[: -len(delim)]
+    return re.fullmatch(r"[\s]*(\\[a-z])*", prefix) is not None
+
+
+def _mask_heredocs(code: str) -> tuple[str, tuple[tuple[str, str], ...]]:
+    """Replace heredoc body+terminator with a placeholder so shfmt can parse around it.
+
+    Returns (masked_code, blocks) where blocks[i] is (token, original_block_text).
+    """
+    nonce = uuid.uuid4().hex
+    out_lines: list[str] = []
+    blocks: list[tuple[str, str]] = []
+    lines = code.splitlines(keepends=True)
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = _HEREDOC_START.search(line)
+        if not m:
+            out_lines.append(line)
+            i += 1
+            continue
+
+        delim = m.group(1)
+        out_lines.append(line)
+        i += 1
+
+        body_start = i
+        terminator_idx: int | None = None
+        while i < len(lines):
+            if _looks_like_terminator(lines[i], delim):
+                terminator_idx = i
+                break
+            i += 1
+
+        if terminator_idx is None:
+            out_lines.extend(lines[body_start:])
+            return "".join(out_lines), tuple(blocks)
+
+        original_block = "".join(lines[body_start : terminator_idx + 1])
+        token = _HEREDOC_TOKEN_FMT.format(nonce=nonce, idx=len(blocks))
+        blocks.append((token, original_block))
+
+        out_lines.append(token + "\n")
+        out_lines.append(delim + "\n")
+        i = terminator_idx + 1
+
+    return "".join(out_lines), tuple(blocks)
+
+
+def _unmask_heredocs(code: str, blocks: tuple[tuple[str, str], ...]) -> str:
+    """Restore heredoc bodies + terminators masked by _mask_heredocs."""
+    for token, original in blocks:
+        marker = re.compile(re.escape(token) + r"[^\n]*\n[^\n]*\n")
+        code = marker.sub(lambda _m: original, code, count=1)
+    return code
+
+
 def format_shell_code(code: str) -> str:
     """Format shell code using shfmt, preserving Snakemake `{var}` placeholders."""
-    masked, tokens, originals = _mask_snakemake_vars(code)
+    masked, var_tokens, var_originals = _mask_snakemake_vars(code)
+    masked, heredoc_blocks = _mask_heredocs(masked)
     formatted = _invoke_shfmt(masked)
-    return _unmask_snakemake_vars(formatted, tokens, originals)
+    formatted = _unmask_heredocs(formatted, heredoc_blocks)
+    return _unmask_snakemake_vars(formatted, var_tokens, var_originals)
 
 
 _HEREDOC_START = re.compile(r"<<-?\s*['\"]?([^'\"\s<>|;&()]+)['\"]?")

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -1,0 +1,97 @@
+import re
+import subprocess
+import textwrap
+
+from snakefmt.exceptions import InvalidShell
+
+TAB = "    "
+
+# Matches `{var}` while ignoring escaped `{{...}}` braces (which Snakemake
+# passes through to the shell verbatim, e.g. `awk '{{print $1}}'`).
+# The leading character class avoids matching shell function bodies like
+# `foo() { echo bar }`.
+_SNAKEMAKE_VAR_PATTERN = re.compile(r"(?<!\{)\{([a-zA-Z0-9_][^{}]*)\}(?!\})")
+
+_MASK_TEMPLATE = "__SNAKEFMT_VAR_{}__"
+
+
+def _mask_snakemake_vars(code: str) -> tuple[str, tuple[str, ...]]:
+    """Replace Snakemake `{var}` placeholders with opaque tokens shfmt won't touch."""
+    originals: list[str] = []
+
+    def replace(match: re.Match[str]) -> str:
+        originals.append(match.group(0))
+        return _MASK_TEMPLATE.format(len(originals) - 1)
+
+    masked = _SNAKEMAKE_VAR_PATTERN.sub(replace, code)
+    return masked, tuple(originals)
+
+
+def _unmask_snakemake_vars(code: str, originals: tuple[str, ...]) -> str:
+    """Reverse of `_mask_snakemake_vars`. Walks tokens in reverse to avoid
+    substring collisions between e.g. `__SNAKEFMT_VAR_1__` and `__SNAKEFMT_VAR_10__`."""
+    for i in range(len(originals) - 1, -1, -1):
+        code = code.replace(_MASK_TEMPLATE.format(i), originals[i])
+    return code
+
+
+def _invoke_shfmt(code: str) -> str:
+    """Run the bundled shfmt binary against `code`. Seam for future swaps —
+    see docs/adr/0001-shell-formatter-distribution.md."""
+    try:
+        process = subprocess.run(
+            ["shfmt", "-i", "4", "-ci", "-bn"],
+            input=code,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise InvalidShell(f"Invalid shell code. shfmt error: {e.stderr}")
+    return process.stdout
+
+
+def format_shell_code(code: str) -> str:
+    """Format shell code using shfmt, preserving Snakemake `{var}` placeholders."""
+    masked, originals = _mask_snakemake_vars(code)
+    formatted = _invoke_shfmt(masked)
+    return _unmask_snakemake_vars(formatted, originals)
+
+
+def format_python_string_literal(literal: str, target_indent: int = 0) -> str:
+    """Extracts shell code from a Python string literal, formats it, and re-wraps it."""
+    # We only format multiline strings for safety, as single line strings
+    # might just be a single command or not worth formatting.
+    # This also avoids issues with implicitly concatenated strings.
+    # Strip trailing whitespace: the parser appends a NEWLINE token after the
+    # closing triple-quote, so the literal arrives as '"""..."""\n'. The caller
+    # already rstrips the result, so this is safe.
+    literal = literal.rstrip()
+    match = re.fullmatch(r'^([a-zA-Z]*)(""")([\s\S]*?)(\2)$', literal)
+    if not match:
+        match = re.fullmatch(r"^([a-zA-Z]*)(''')([\s\S]*?)(\2)$", literal)
+
+    if not match:
+        return literal  # Not a simple multiline string literal, don't format
+
+    prefix = match.group(1)
+    quote = match.group(2)
+    content = match.group(3)
+
+    formatted_content = format_shell_code(content)
+
+    # Ensure it ends with a single newline before the closing quotes
+    formatted_content = formatted_content.rstrip("\n") + "\n"
+
+    # Indent the content
+    used_indent = TAB * target_indent
+    indented_content = textwrap.indent(formatted_content, used_indent)
+
+    # Prepend a newline if the first line is indented so it drops below opening quote
+    if indented_content and not indented_content.startswith("\n"):
+        indented_content = "\n" + indented_content
+
+    # Indent the closing quote
+    closing_quote = f"{used_indent}{quote}"
+
+    return f"{prefix}{quote}{indented_content}{closing_quote}"

--- a/snakefmt/shell_formatter.py
+++ b/snakefmt/shell_formatter.py
@@ -1,27 +1,32 @@
 import re
 import subprocess
-import textwrap
 import uuid
 
 from snakefmt.exceptions import InvalidShell
 
 TAB = "    "
 
-# Matches `{var}` while ignoring escaped `{{...}}` braces (which Snakemake
-# passes through to the shell verbatim, e.g. `awk '{{print $1}}'`).
-# The leading character class avoids matching shell function bodies like
-# `foo() { echo bar }`.
-# Intentionally permissive beyond the first character: in Snakemake shell
-# blocks, ALL single {…} are Snakemake expressions by definition — literal
-# braces must use {{…}}. This correctly captures {input[0]}, {threads:02d},
-# {wildcards.sample}, etc.
-_SNAKEMAKE_VAR_PATTERN = re.compile(r"(?<!\{)\{([a-zA-Z0-9_][^{}]*)\}(?!\})")
+# Matches `{{...}}` escaped brace pairs — these encode literal shell `{...}` after
+# Snakemake's str.format() render. Masked FIRST so the single-brace pattern doesn't
+# partially match their inner content. Pattern: any content without nested braces.
+_DOUBLE_BRACE_PATTERN = re.compile(r"\{\{[^{}]*\}\}")
+
+# Matches single `{var}` Snakemake placeholders. The leading character class avoids
+# matching shell function bodies like `foo() { echo bar }`. The negative
+# lookahead/lookbehind guards against `{{...}}` which was already masked above.
+# Intentionally permissive beyond the first character: captures {input[0]},
+# {threads:02d}, {wildcards.sample}, etc.
+_SINGLE_BRACE_PATTERN = re.compile(r"(?<!\{)\{([a-zA-Z0-9_][^{}]*)\}(?!\})")
 
 
 def _mask_snakemake_vars(code: str) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
-    """Replace Snakemake `{var}` placeholders with opaque tokens shfmt won't touch.
+    """Replace Snakemake placeholders and escaped brace pairs with opaque tokens.
 
-    Uses a per-call UUID nonce in the token to eliminate any risk of collision
+    Masks in two passes: `{{...}}` first, then single `{var}` placeholders. This
+    ordering prevents the single-brace pattern from matching inside double-brace
+    content and ensures both forms survive shfmt unchanged.
+
+    Uses a per-call UUID nonce in each token to eliminate any risk of collision
     with literal text that happens to look like a mask token.
 
     Returns (masked_code, tokens, originals) — tokens[i] is the exact string
@@ -38,8 +43,9 @@ def _mask_snakemake_vars(code: str) -> tuple[str, tuple[str, ...], tuple[str, ..
         originals.append(match.group(0))
         return token
 
-    masked = _SNAKEMAKE_VAR_PATTERN.sub(replace, code)
-    return masked, tuple(tokens), tuple(originals)
+    code = _DOUBLE_BRACE_PATTERN.sub(replace, code)
+    code = _SINGLE_BRACE_PATTERN.sub(replace, code)
+    return code, tuple(tokens), tuple(originals)
 
 
 def _unmask_snakemake_vars(
@@ -75,21 +81,54 @@ def format_shell_code(code: str) -> str:
     return _unmask_snakemake_vars(formatted, tokens, originals)
 
 
+_HEREDOC_START = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?")
+
+# Matches any Python triple-quoted string literal, with or without a prefix (f, r, b,
+# etc.). Uses `"{3}|'{3}` so the closing backreference \2 matches the same quote style
+# without needing backslash escapes that confuse formatters inside raw strings.
+_TRIPLE_QUOTE_RE = re.compile(r"""^([a-zA-Z]*)("{3}|'{3})([\s\S]*?)(\2)$""")
+
+
+def _indent_preserving_heredocs(text: str, indent: str) -> str:
+    """Indent each line by `indent`, skipping heredoc body and terminator lines.
+
+    shfmt does not reformat heredoc bodies. This function mirrors that — it adds
+    the target indent to command lines but leaves heredoc content untouched so that
+    terminator words remain at column 0 (required by bash for `<<EOF`) or with only
+    leading tabs (for `<<-EOF`).
+    """
+    out_lines: list[str] = []
+    in_heredoc: str | None = None
+    for line in text.splitlines(keepends=True):
+        stripped = line.rstrip("\n")
+        if in_heredoc is not None:
+            out_lines.append(line)
+            if stripped == in_heredoc or stripped.lstrip("\t") == in_heredoc:
+                in_heredoc = None
+            continue
+        out_lines.append(indent + line if line.strip() else line)
+        m = _HEREDOC_START.search(line)
+        if m:
+            in_heredoc = m.group(1)
+    return "".join(out_lines)
+
+
 def format_python_string_literal(literal: str, target_indent: int = 0) -> str:
-    """Extracts shell code from a Python string literal, formats it, and re-wraps it."""
-    # We only format multiline strings for safety, as single line strings
-    # might just be a single command or not worth formatting.
-    # This also avoids issues with implicitly concatenated strings.
+    """Extracts shell code from a Python string literal, formats it, and re-wraps it.
+
+    Only multiline triple-quoted strings are formatted. Single-line strings and any
+    form that doesn't match a simple triple-quote pattern are returned unchanged.
+    The literal is expected to arrive from `str(parameter)` — the caller guarantees
+    no leading whitespace beyond what the parser appends (handled by `rstrip` below).
+    """
     # Strip trailing whitespace: the parser appends a NEWLINE token after the
     # closing triple-quote, so the literal arrives as '"""..."""\n'. The caller
     # already rstrips the result, so this is safe.
     literal = literal.rstrip()
-    match = re.fullmatch(r'^([a-zA-Z]*)(""")([\s\S]*?)(\2)$', literal)
-    if not match:
-        match = re.fullmatch(r"^([a-zA-Z]*)(''')([\s\S]*?)(\2)$", literal)
+    match = _TRIPLE_QUOTE_RE.fullmatch(literal)
 
     if not match:
-        return literal  # Not a simple multiline string literal, don't format
+        return literal  # not a triple-quoted string literal; return unchanged
 
     prefix = match.group(1)
     quote = match.group(2)
@@ -100,9 +139,9 @@ def format_python_string_literal(literal: str, target_indent: int = 0) -> str:
     # Ensure it ends with a single newline before the closing quotes
     formatted_content = formatted_content.rstrip("\n") + "\n"
 
-    # Indent the content
+    # Indent the content, preserving heredoc terminator placement
     used_indent = TAB * target_indent
-    indented_content = textwrap.indent(formatted_content, used_indent)
+    indented_content = _indent_preserving_heredocs(formatted_content, used_indent)
 
     # Prepend a newline if the first line is indented so it drops below opening quote
     if indented_content and not indented_content.startswith("\n"):

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -261,12 +261,12 @@ def main(
 
         try:
             snakefile = Snakefile(StringIO(original_content))
-            snakefile.format_shell = format_shell
             formatter = Formatter(
                 snakefile,
                 line_length=line_length,
                 sort_directives=sort_directives,
                 black_config_file=config,
+                format_shell=format_shell,
             )
             formatted_content = formatter.get_formatted()
         except Exception as error:

--- a/snakefmt/snakefmt.py
+++ b/snakefmt/snakefmt.py
@@ -94,6 +94,14 @@ def get_snakefiles_in_dir(
     show_default=True,
 )
 @click.option(
+    "--format-shell/--no-format-shell",
+    "-f/-F",
+    "format_shell",
+    default=True,
+    help="Format shell directives using shfmt.",
+    show_default=True,
+)
+@click.option(
     "--check",
     is_flag=True,
     help=(
@@ -174,6 +182,7 @@ def main(
     ctx: click.Context,
     line_length: int,
     sort_directives: bool,
+    format_shell: bool,
     check: bool,
     diff: bool,
     compact_diff: bool,
@@ -252,6 +261,7 @@ def main(
 
         try:
             snakefile = Snakefile(StringIO(original_content))
+            snakefile.format_shell = format_shell
             formatter = Formatter(
                 snakefile,
                 line_length=line_length,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,6 +11,7 @@ def setup_formatter(
     line_length: int | None = None,
     sort_params: bool = False,
     black_config_file=None,
+    format_shell: bool = False,
 ):
     stream = StringIO(snake)
     smk = Snakefile(stream)
@@ -20,4 +21,5 @@ def setup_formatter(
         line_length=line_length,
         sort_directives=sort_params,
         black_config_file=black_config_file,
+        format_shell=format_shell,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -304,6 +304,54 @@ class TestReadBlackConfig:
         assert formatter.black_mode == expected
 
 
+class TestShellFormattingConfig:
+    """Config-driven control of shell block formatting."""
+
+    _UNFORMATTED_STDIN = (
+        "rule align:\n"
+        f"{TAB}shell:\n"
+        f'{TAB * 2}"""\n'
+        f"{TAB * 2}if [ -s /tmp/out ]\n"
+        f"{TAB * 2}then\n"
+        f"{TAB * 2}echo done\n"
+        f"{TAB * 2}fi\n"
+        f'{TAB * 2}"""\n'
+    )
+
+    def test_format_shell_false_in_config_disables_formatting(
+        self, cli_runner, tmp_path
+    ):
+        """format_shell = false in [tool.snakefmt] leaves shell bodies untouched."""
+        config = tmp_path / "pyproject.toml"
+        config.write_text("[tool.snakefmt]\nformat_shell = false\n")
+        params = ["--config", str(config), "-"]
+
+        actual = cli_runner.invoke(main, params, input=self._UNFORMATTED_STDIN)
+
+        assert actual.exit_code == 0
+        assert actual.stdout == self._UNFORMATTED_STDIN
+
+    def test_format_shell_true_in_config_formats_shell(self, cli_runner, tmp_path):
+        """format_shell = true in [tool.snakefmt] formats shell bodies via shfmt."""
+        config = tmp_path / "pyproject.toml"
+        config.write_text("[tool.snakefmt]\nformat_shell = true\n")
+        params = ["--config", str(config), "-"]
+
+        actual = cli_runner.invoke(main, params, input=self._UNFORMATTED_STDIN)
+
+        expected = (
+            "rule align:\n"
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}if [ -s /tmp/out ]; then\n"
+            f"{TAB * 3}echo done\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        assert actual.exit_code == 0
+        assert actual.stdout == expected
+
+
 class TestFindProjectRoot:
     def test_stdin_filename(self, tmp_path):
         from snakefmt.config import find_project_root

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -2926,7 +2926,10 @@ class TestShellBlockFormatting:
 
     def test_default_on_formats_shell(self):
         """Shell formatting is enabled by default and reformats shell content."""
-        assert setup_formatter(self._UNFORMATTED).get_formatted() == self._FORMATTED
+        assert (
+            setup_formatter(self._UNFORMATTED, format_shell=True).get_formatted()
+            == self._FORMATTED
+        )
 
     def test_format_shell_false_preserves_shell(self):
         """Setting format_shell=False leaves the shell body untouched."""
@@ -2936,8 +2939,7 @@ class TestShellBlockFormatting:
         from snakefmt.parser.parser import Snakefile
 
         smk = Snakefile(StringIO(self._UNFORMATTED))
-        smk.format_shell = False
-        assert Formatter(smk).get_formatted() == self._UNFORMATTED
+        assert Formatter(smk, format_shell=False).get_formatted() == self._UNFORMATTED
 
     def test_fmt_off_opts_out_of_shell_formatting(self):
         """A # fmt: off / # fmt: on region prevents shell formatting."""
@@ -2953,7 +2955,7 @@ class TestShellBlockFormatting:
             f'{TAB * 2}"""\n'
             "# fmt: on\n"
         )
-        assert setup_formatter(code).get_formatted() == code
+        assert setup_formatter(code, format_shell=True).get_formatted() == code
 
     def test_snakemake_placeholders_preserved_end_to_end(self):
         """{var}, {var.attr}, and {{escaped}} placeholders survive the full
@@ -2987,4 +2989,68 @@ class TestShellBlockFormatting:
             f"{TAB * 2}fi\n"
             f'{TAB * 2}"""\n'
         )
-        assert setup_formatter(unformatted).get_formatted() == expected
+        assert (
+            setup_formatter(unformatted, format_shell=True).get_formatted() == expected
+        )
+
+    def test_heredoc_terminator_at_column_zero(self):
+        """<<EOF terminator must stay at column 0 after snakefmt re-indents content."""
+        unformatted = (
+            "rule a:\n"
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}if true\n"
+            f"{TAB * 2}then\n"
+            f"{TAB * 2}cat <<EOF >/dev/null\n"
+            f"line1\n"
+            f"EOF\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        expected = (
+            "rule a:\n"
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}if true; then\n"
+            f"{TAB * 3}cat <<EOF >/dev/null\n"
+            f"line1\n"
+            f"EOF\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        assert (
+            setup_formatter(unformatted, format_shell=True).get_formatted() == expected
+        )
+
+    def test_heredoc_with_snakemake_variable(self):
+        """Snakemake {output} in a heredoc command line survives the full pipeline.
+
+        shfmt reformats the command line (strips the space before the redirect),
+        but leaves the heredoc body and terminator untouched.
+        """
+        unformatted = (
+            "rule a:\n"
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}if true\n"
+            f"{TAB * 2}then\n"
+            f"{TAB * 2}cat <<EOF > {{output}}\n"  # space before {output}
+            f"content\n"
+            f"EOF\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        expected = (
+            "rule a:\n"
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}if true; then\n"
+            f"{TAB * 3}cat <<EOF >{{output}}\n"  # space removed by shfmt
+            f"content\n"
+            f"EOF\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        assert (
+            setup_formatter(unformatted, format_shell=True).get_formatted() == expected
+        )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -861,7 +861,14 @@ rule a:
   \t\tTabbed
     """
 '''
-        formatter = setup_formatter(snakecode)
+        from io import StringIO
+
+        from snakefmt.formatter import Formatter
+        from snakefmt.parser.parser import Snakefile
+
+        snakefile = Snakefile(StringIO(snakecode))
+        snakefile.format_shell = False
+        formatter = Formatter(snakefile)
 
         expected = f'''
 rule a:
@@ -888,7 +895,14 @@ EOF
 bash tmp.txt
         """
 '''
-        formatter = setup_formatter(snakecode)
+        from io import StringIO
+
+        from snakefmt.formatter import Formatter
+        from snakefmt.parser.parser import Snakefile
+
+        snakefile = Snakefile(StringIO(snakecode))
+        snakefile.format_shell = False
+        formatter = Formatter(snakefile)
 
         assert formatter.get_formatted() == snakecode
 
@@ -901,7 +915,14 @@ bash tmp.txt
             f"{TAB * 1}print('Hello, world!')\n"
             f'{TAB * 2}"""'
         )
-        formatter = setup_formatter(snakecode)
+        from io import StringIO
+
+        from snakefmt.formatter import Formatter
+        from snakefmt.parser.parser import Snakefile
+
+        snakefile = Snakefile(StringIO(snakecode))
+        snakefile.format_shell = False
+        formatter = Formatter(snakefile)
         expected = (
             "rule a:\n"
             f"{TAB * 1}shell:\n"
@@ -2874,3 +2895,96 @@ class TestFmtOffNext:
             f"{TAB}input:\n"
             f'{TAB * 2}"qux",\n'
         )
+
+
+class TestShellBlockFormatting:
+    """End-to-end tests for shell block formatting via shfmt.
+
+    The unformatted input uses an if/then/fi block that shfmt normalises to
+    `if ...; then` form — a visible, deterministic transformation we can assert on.
+    """
+
+    _UNFORMATTED = (
+        "rule align:\n"
+        f"{TAB}shell:\n"
+        f'{TAB * 2}"""\n'
+        f"{TAB * 2}if [ -s /tmp/out ]\n"
+        f"{TAB * 2}then\n"
+        f"{TAB * 2}echo done\n"
+        f"{TAB * 2}fi\n"
+        f'{TAB * 2}"""\n'
+    )
+    _FORMATTED = (
+        "rule align:\n"
+        f"{TAB}shell:\n"
+        f'{TAB * 2}"""\n'
+        f"{TAB * 2}if [ -s /tmp/out ]; then\n"
+        f"{TAB * 3}echo done\n"
+        f"{TAB * 2}fi\n"
+        f'{TAB * 2}"""\n'
+    )
+
+    def test_default_on_formats_shell(self):
+        """Shell formatting is enabled by default and reformats shell content."""
+        assert setup_formatter(self._UNFORMATTED).get_formatted() == self._FORMATTED
+
+    def test_format_shell_false_preserves_shell(self):
+        """Setting format_shell=False leaves the shell body untouched."""
+        from io import StringIO
+
+        from snakefmt.formatter import Formatter
+        from snakefmt.parser.parser import Snakefile
+
+        smk = Snakefile(StringIO(self._UNFORMATTED))
+        smk.format_shell = False
+        assert Formatter(smk).get_formatted() == self._UNFORMATTED
+
+    def test_fmt_off_opts_out_of_shell_formatting(self):
+        """A # fmt: off / # fmt: on region prevents shell formatting."""
+        code = (
+            "# fmt: off\n"
+            "rule align:\n"
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}if [ -s /tmp/out ]\n"
+            f"{TAB * 2}then\n"
+            f"{TAB * 2}echo done\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+            "# fmt: on\n"
+        )
+        assert setup_formatter(code).get_formatted() == code
+
+    def test_snakemake_placeholders_preserved_end_to_end(self):
+        """{var}, {var.attr}, and {{escaped}} placeholders survive the full
+        parse -> mask -> shfmt -> unmask -> render pipeline."""
+        unformatted = (
+            "rule align:\n"
+            f"{TAB}input:\n"
+            f'{TAB * 2}"reads.fq",\n'
+            f"{TAB}output:\n"
+            f'{TAB * 2}"aligned.bam",\n'
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}awk '{{{{print $1}}}}' {{input}} > {{output}}\n"
+            f"{TAB * 2}if [ -s {{output}} ]\n"
+            f"{TAB * 2}then\n"
+            f"{TAB * 2}echo done\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        expected = (
+            "rule align:\n"
+            f"{TAB}input:\n"
+            f'{TAB * 2}"reads.fq",\n'
+            f"{TAB}output:\n"
+            f'{TAB * 2}"aligned.bam",\n'
+            f"{TAB}shell:\n"
+            f'{TAB * 2}"""\n'
+            f"{TAB * 2}awk '{{{{print $1}}}}' {{input}} >{{output}}\n"
+            f"{TAB * 2}if [ -s {{output}} ]; then\n"
+            f"{TAB * 3}echo done\n"
+            f"{TAB * 2}fi\n"
+            f'{TAB * 2}"""\n'
+        )
+        assert setup_formatter(unformatted).get_formatted() == expected

--- a/tests/test_shell_formatter.py
+++ b/tests/test_shell_formatter.py
@@ -107,9 +107,9 @@ awk '{{print $1}}' {input}
 
 def test_format_shell_code_many_variables():
     # Tests that __SNAKEFMT_VAR_1__ doesn't accidentally replace __SNAKEFMT_VAR_10__
-    vars = [f"{{var{i}}}" for i in range(15)]
-    unformatted = "echo " + " ".join(vars) + "\n"
-    expected = "echo " + " ".join(vars) + "\n"
+    placeholders = [f"{{var{i}}}" for i in range(15)]
+    unformatted = "echo " + " ".join(placeholders) + "\n"
+    expected = "echo " + " ".join(placeholders) + "\n"
     assert format_shell_code(unformatted) == expected
 
 

--- a/tests/test_shell_formatter.py
+++ b/tests/test_shell_formatter.py
@@ -1,7 +1,11 @@
 import pytest
 
 from snakefmt.exceptions import InvalidShell
-from snakefmt.shell_formatter import format_python_string_literal, format_shell_code
+from snakefmt.shell_formatter import (
+    _indent_preserving_heredocs,
+    format_python_string_literal,
+    format_shell_code,
+)
 
 # Shell content that shfmt will reformat (not already at fixed-point).
 # Input: un-indented if/then/fi without semicolon-compression.
@@ -116,3 +120,103 @@ def test_format_shell_code_invalid_syntax():
     """
     with pytest.raises(InvalidShell):
         format_shell_code(unformatted)
+
+
+def test_format_shell_code_double_brace_param_expansion():
+    # ${{VAR}} in Snakemake source → ${VAR} in shell → must round-trip verbatim.
+    code = "echo ${{VAR}} ${{VAR:-default}}\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_double_brace_expansion():
+    # {{a,b,c}} → {a,b,c} brace expansion in shell.
+    code = "cp f{{1,2}}.txt output/\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_brace_group_preserved():
+    # Brace group {{ echo hi; echo bye; }} is masked verbatim — body not internally
+    # reformatted (accepted trade-off: brace count must survive str.format()).
+    code = "{{ echo hi; echo bye; }}\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_awk_double_braces():
+    # awk '{{print $1}}' — already tested but confirm it still works after C1.
+    code = "awk '{{print $1}}' {input}\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_python_string_literal_fstring_formatted():
+    # F-string shell blocks must be formatted, not skipped.
+    # {{output}} is a Snakemake variable in f-string context (Python collapses
+    # {{}} → {}, then Snakemake substitutes). It must round-trip verbatim.
+    literal = 'f"""\necho {{output}}\nls -l\n"""'
+    result = format_python_string_literal(literal, target_indent=0)
+    assert "{{output}}" in result
+    assert result.startswith('f"""')
+
+
+def test_format_shell_code_long_line_no_spurious_wrap():
+    # shfmt with -i 4 -ci -bn is syntactic only — no length-based line wrapping.
+    # Mask tokens (~50 chars each) must not cause spurious line breaks post-unmask.
+    vars_str = " ".join(f"{{var{i}}}" for i in range(10))
+    unformatted = f"echo {vars_str}\n"
+    assert format_shell_code(unformatted) == unformatted
+
+
+class TestIndentPreservingHeredocs:
+    def test_plain_lines_indented(self):
+        text = "echo hello\necho world\n"
+        result = _indent_preserving_heredocs(text, "    ")
+        assert result == "    echo hello\n    echo world\n"
+
+    def test_blank_lines_not_indented(self):
+        text = "echo hi\n\necho bye\n"
+        result = _indent_preserving_heredocs(text, "    ")
+        assert result == "    echo hi\n\n    echo bye\n"
+
+    def test_heredoc_body_and_terminator_not_indented(self):
+        text = "cat <<EOF\nbody line\nEOF\n"
+        result = _indent_preserving_heredocs(text, "    ")
+        assert result == "    cat <<EOF\nbody line\nEOF\n"
+
+    def test_heredoc_dash_terminator_with_leading_tabs(self):
+        # <<-EOF: terminator may have leading tabs — still recognised as terminator.
+        text = "cat <<-EOF\n\tbody line\n\tEOF\n"
+        result = _indent_preserving_heredocs(text, "    ")
+        assert result == "    cat <<-EOF\n\tbody line\n\tEOF\n"
+
+    def test_heredoc_quoted_terminator(self):
+        # <<'EOF' suppresses substitution in the body but terminator is same word.
+        text = "cat <<'EOF'\nbody line\nEOF\n"
+        result = _indent_preserving_heredocs(text, "    ")
+        assert result == "    cat <<'EOF'\nbody line\nEOF\n"
+
+    def test_multiple_commands_after_heredoc(self):
+        text = "cat <<EOF\nbody\nEOF\necho done\n"
+        result = _indent_preserving_heredocs(text, "    ")
+        assert result == "    cat <<EOF\nbody\nEOF\n    echo done\n"
+
+
+class TestFormatPythonStringLiteralHeredocs:
+    def test_heredoc_terminator_at_column_zero(self):
+        # <<EOF: terminator must remain at column 0 after snakefmt indentation.
+        # The user writes the heredoc with the terminator at col 0 in the source.
+        literal = '"""\ncat <<EOF\nsome content\nEOF\n"""'
+        result = format_python_string_literal(literal, target_indent=2)
+        # Command is indented; body and terminator are NOT.
+        assert "        cat <<EOF\n" in result
+        assert "\nsome content\n" in result
+        assert "\nEOF\n" in result
+        # Terminator must not be preceded by spaces on its line.
+        for line in result.splitlines():
+            if line.strip() == "EOF":
+                assert line == "EOF", f"Terminator line is indented: {line!r}"
+
+    def test_heredoc_with_snakemake_variable_in_command(self):
+        # Snakemake {output} in the command line of a heredoc — must survive.
+        literal = '"""\ncat <<EOF >{output}\nsome content\nEOF\n"""'
+        result = format_python_string_literal(literal, target_indent=2)
+        assert "{output}" in result
+        assert "EOF\n" in result

--- a/tests/test_shell_formatter.py
+++ b/tests/test_shell_formatter.py
@@ -237,5 +237,10 @@ class TestFormatPythonStringLiteralHeredocs:
     def test_heredoc_with_custom_delimiter_and_newlines(self):
         # Simulates a Python multi-line string containing a heredoc
         literal = '"""\npython <<!EOF!\n\\nif True:\n\npass\n\n\\n\n!EOF!\n"""'
-        expected = '"""\n        python <<!EOF!\n\\nif True:\n\npass\n\n\\n\n!EOF!\n        """'
+        expected = (
+            '"""\n'
+            '        python <<!EOF!\n'
+            '\\nif True:\n\npass\n\n\\n\n!EOF!\n'
+            '        """'
+        )
         assert format_python_string_literal(literal, target_indent=2) == expected

--- a/tests/test_shell_formatter.py
+++ b/tests/test_shell_formatter.py
@@ -147,6 +147,19 @@ def test_format_shell_code_awk_double_braces():
     assert format_shell_code(code) == code
 
 
+def test_format_shell_code_awk_double_braces_with_inner_var():
+    # {{...}} containing a single {var} must be preserved and not mangled by shfmt.
+    code = "awk '{{print {params.a} }}'\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_unquoted_double_braces_with_inner_var():
+    # Unquoted {{...}} containing a variable must be masked entirely by the double
+    # brace pass so that shfmt doesn't reformat the inside as nested brace groups.
+    code = "{{\n    echo {params.a}\n}}\n"
+    assert format_shell_code(code) == code
+
+
 def test_format_python_string_literal_fstring_formatted():
     # F-string shell blocks must be formatted, not skipped.
     # {{output}} is a Snakemake variable in f-string context (Python collapses
@@ -220,3 +233,9 @@ class TestFormatPythonStringLiteralHeredocs:
         result = format_python_string_literal(literal, target_indent=2)
         assert "{output}" in result
         assert "EOF\n" in result
+
+    def test_heredoc_with_custom_delimiter_and_newlines(self):
+        # Simulates a Python multi-line string containing a heredoc
+        literal = '"""\npython <<!EOF!\n\\nif True:\n\npass\n\n\\n\n!EOF!\n"""'
+        expected = '"""\n        python <<!EOF!\n\\nif True:\n\npass\n\n\\n\n!EOF!\n        """'
+        assert format_python_string_literal(literal, target_indent=2) == expected

--- a/tests/test_shell_formatter.py
+++ b/tests/test_shell_formatter.py
@@ -1,0 +1,118 @@
+import pytest
+
+from snakefmt.exceptions import InvalidShell
+from snakefmt.shell_formatter import format_python_string_literal, format_shell_code
+
+# Shell content that shfmt will reformat (not already at fixed-point).
+# Input: un-indented if/then/fi without semicolon-compression.
+# Output: shfmt normalises to `if ...; then` form with 4-space body indent.
+_UNFORMATTED_CONTENT = "if [ -s /tmp/out ]\nthen\necho done\nfi"
+_EXPECTED_CONTENT = "if [ -s /tmp/out ]; then\n    echo done\nfi\n"
+_EXPECTED_LITERAL = f'"""\n{_EXPECTED_CONTENT}"""'
+
+
+def test_format_python_string_literal():
+    literal = 'f"""\n      echo {input}\n    ls -l\n    """'
+    expected = 'f"""\n        echo {input}\n        ls -l\n        """'
+    assert format_python_string_literal(literal, target_indent=2) == expected
+
+
+@pytest.mark.parametrize(
+    "literal,expected",
+    [
+        # 1. Trailing \n after closing quotes — the actual parser-output bug.
+        (
+            f'"""\n{_UNFORMATTED_CONTENT}\n"""\n',
+            _EXPECTED_LITERAL,
+        ),
+        # 2. Multiple trailing newlines.
+        (
+            f'"""\n{_UNFORMATTED_CONTENT}\n"""\n\n',
+            _EXPECTED_LITERAL,
+        ),
+        # 3. Trailing spaces / tabs after closing quotes.
+        (
+            f'"""\n{_UNFORMATTED_CONTENT}\n"""   \t',
+            _EXPECTED_LITERAL,
+        ),
+        # 4. \r\n line endings inside — shfmt normalises to \n in output.
+        (
+            '"""\r\n' + _UNFORMATTED_CONTENT.replace("\n", "\r\n") + '\r\n"""',
+            _EXPECTED_LITERAL,
+        ),
+        # 5. String prefix variants — prefix must be preserved, content formatted.
+        (f'f"""\n{_UNFORMATTED_CONTENT}\n"""\n', f'f"""\n{_EXPECTED_CONTENT}"""'),
+        (f'rb"""\n{_UNFORMATTED_CONTENT}\n"""\n', f'rb"""\n{_EXPECTED_CONTENT}"""'),
+        (f'B"""\n{_UNFORMATTED_CONTENT}\n"""\n', f'B"""\n{_EXPECTED_CONTENT}"""'),
+        (f'u"""\n{_UNFORMATTED_CONTENT}\n"""\n', f'u"""\n{_EXPECTED_CONTENT}"""'),
+    ],
+    ids=[
+        "trailing_newline",
+        "multiple_trailing_newlines",
+        "trailing_spaces_tabs",
+        "crlf_line_endings",
+        "prefix_f",
+        "prefix_rb",
+        "prefix_B",
+        "prefix_u",
+    ],
+)
+def test_format_python_string_literal_trailing_whitespace_shapes(literal, expected):
+    """format_python_string_literal must format content regardless of trailing
+    whitespace after the closing quotes — the form produced by the parser."""
+    assert format_python_string_literal(literal, target_indent=0) == expected
+
+
+def test_format_shell_code_simple():
+    unformatted = """
+        echo "hello"
+          ls -l
+    """
+    expected = """\
+echo "hello"
+ls -l
+"""
+    assert format_shell_code(unformatted) == expected
+
+
+def test_format_shell_code_with_variables():
+    unformatted = """
+        echo {input.foo} > {output[0]}
+        for f in {input}; do
+            cat $f
+        done
+    """
+    expected = """\
+echo {input.foo} >{output[0]}
+for f in {input}; do
+    cat $f
+done
+"""
+    assert format_shell_code(unformatted) == expected
+
+
+def test_format_shell_code_escaped_braces():
+    unformatted = """
+        awk '{{print $1}}' {input}
+    """
+    expected = """\
+awk '{{print $1}}' {input}
+"""
+    assert format_shell_code(unformatted) == expected
+
+
+def test_format_shell_code_many_variables():
+    # Tests that __SNAKEFMT_VAR_1__ doesn't accidentally replace __SNAKEFMT_VAR_10__
+    vars = [f"{{var{i}}}" for i in range(15)]
+    unformatted = "echo " + " ".join(vars) + "\n"
+    expected = "echo " + " ".join(vars) + "\n"
+    assert format_shell_code(unformatted) == expected
+
+
+def test_format_shell_code_invalid_syntax():
+    unformatted = """
+        if [ -z "foo" ]; then
+            echo "bar"
+    """
+    with pytest.raises(InvalidShell):
+        format_shell_code(unformatted)

--- a/tests/test_shell_formatter.py
+++ b/tests/test_shell_formatter.py
@@ -170,6 +170,33 @@ def test_format_python_string_literal_fstring_formatted():
     assert result.startswith('f"""')
 
 
+def test_format_shell_code_heredoc_with_snakemake_escape_terminator():
+    code = "python <<!EOF!\n" "\\nif True:\n" "    pass\n" "\n" "\\n!EOF!\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_heredoc_body_never_reformatted():
+    code = "cat <<EOF\n" "if true\nthen\necho yes\nfi\n" "EOF\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_multiple_heredocs():
+    code = "cat <<EOF\nbody1\nEOF\n" "cat <<END\nbody2\nEND\n"
+    assert format_shell_code(code) == code
+
+
+def test_format_shell_code_heredoc_surrounded_by_formatted_shell():
+    unformatted = "if true\nthen\n" "cat <<EOF\nbody\nEOF\n" "fi\n"
+    expected = "if true; then\n" "    cat <<EOF\nbody\nEOF\n" "fi\n"
+    assert format_shell_code(unformatted) == expected
+
+
+def test_format_shell_code_truly_unclosed_heredoc_raises():
+    code = "cat <<EOF\nbody with no terminator anywhere\n"
+    with pytest.raises(InvalidShell):
+        format_shell_code(code)
+
+
 def test_format_shell_code_long_line_no_spurious_wrap():
     # shfmt with -i 4 -ci -bn is syntactic only — no length-based line wrapping.
     # Mask tokens (~50 chars each) must not cause spurious line breaks post-unmask.
@@ -239,8 +266,8 @@ class TestFormatPythonStringLiteralHeredocs:
         literal = '"""\npython <<!EOF!\n\\nif True:\n\npass\n\n\\n\n!EOF!\n"""'
         expected = (
             '"""\n'
-            '        python <<!EOF!\n'
-            '\\nif True:\n\npass\n\n\\n\n!EOF!\n'
+            "        python <<!EOF!\n"
+            "\\nif True:\n\npass\n\n\\n\n!EOF!\n"
             '        """'
         )
         assert format_python_string_literal(literal, target_indent=2) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -984,6 +984,12 @@ wheels = [
 ]
 
 [[package]]
+name = "shfmt-py"
+version = "3.12.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/d9/a1ea26749bd19467e9fbfe7b34e6c8df517e01de4028a45b954eebe8c03b/shfmt_py-3.12.0.2.tar.gz", hash = "sha256:6a0dc675b37d000eb236609cf15aedd9e7a538927ea02c57b617908b6f237e9c", size = 4467, upload-time = "2025-07-08T06:54:40.396Z" }
+
+[[package]]
 name = "smart-open"
 version = "7.3.0.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -1011,6 +1017,7 @@ source = { editable = "." }
 dependencies = [
     { name = "black" },
     { name = "click" },
+    { name = "shfmt-py" },
 ]
 
 [package.dev-dependencies]
@@ -1027,6 +1034,7 @@ dev = [
 requires-dist = [
     { name = "black", specifier = ">=26.3.1,<27" },
     { name = "click", specifier = ">=8.2.0,<9" },
+    { name = "shfmt-py", specifier = ">=3.12.0.2" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -985,9 +985,16 @@ wheels = [
 
 [[package]]
 name = "shfmt-py"
-version = "3.12.0.2"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/d9/a1ea26749bd19467e9fbfe7b34e6c8df517e01de4028a45b954eebe8c03b/shfmt_py-3.12.0.2.tar.gz", hash = "sha256:6a0dc675b37d000eb236609cf15aedd9e7a538927ea02c57b617908b6f237e9c", size = 4467, upload-time = "2025-07-08T06:54:40.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/d5/c2ad5c6593a34da7344cf39bde65763e8cda752589074ba1619e55b317ad/shfmt_py-4.0.0.tar.gz", hash = "sha256:1e5fdacf40aabaa77a97639d52a6220df0893b46658d82b7f136f4e66e2b2fb0", size = 11947, upload-time = "2026-05-13T09:25:50.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/1d/8f72824e2a0e06dc0bc2687baacaba0573be7d2e93c01d1e895fddd8c13e/shfmt_py-4.0.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:75a4919a03fb3bcff9795e3cc7b971e37e74905654d2f11605001cab42e5f92f", size = 1343695, upload-time = "2026-05-13T09:25:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/82/9564a2c2a76fbec94db1b3a3c37a9a1d00e7eafca2cdd2e0d19082618d7e/shfmt_py-4.0.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb3d236163ff39c7790953e069938caf247e7646399f7a059f00f65d4e6916d6", size = 1237947, upload-time = "2026-05-13T09:25:44.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a9/6fce944efa530db941edd11388d70dc7384aaf12169a3b0847b6a6c987b0/shfmt_py-4.0.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:4701336c3cb5f3959a5e85481b14f02054ea094b3c666f3d04649bbe10de3c25", size = 1218771, upload-time = "2026-05-13T09:25:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/64/43/e3965a25bb39555f2791c6860214f62b6f976f9ac7e9786073364bcdd9a6/shfmt_py-4.0.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:e57877abe0177a9da7bbb5390fe7e96aa19b00958189a025634039aef8834d44", size = 1350939, upload-time = "2026-05-13T09:25:47.584Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/db2430d9262d2cffadcad2b330441e13031f1ab849ec069659edb7f23257/shfmt_py-4.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:bd4f3d36264d4ba8b014ff73e5e702aaa2345845c021f563480128de3705135b", size = 1427721, upload-time = "2026-05-13T09:25:48.865Z" },
+]
 
 [[package]]
 name = "smart-open"
@@ -1034,7 +1041,7 @@ dev = [
 requires-dist = [
     { name = "black", specifier = ">=26.3.1,<27" },
     { name = "click", specifier = ">=8.2.0,<9" },
-    { name = "shfmt-py", specifier = ">=3.12.0.2" },
+    { name = "shfmt-py", specifier = ">=4.0.0,<5.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Formats the body of `shell:` directives using [`shfmt`](https://github.com/mvdan/sh), enabled by default (`-f`/`--format-shell`, opt-out with `-F`/`--no-format-shell` or `format_shell = false` in `pyproject.toml`)
- Snakemake `{var}` placeholders are masked before formatting and restored verbatim; escaped `{{...}}` braces are passed through unchanged
- Invalid shell raises `InvalidShell` rather than crashing silently; escape hatches are `-F` or `# fmt: off`
- Ships via [`shfmt-py`](https://github.com/MaxWinterstein/shfmt-py) — no separate user install required; distribution decision documented in [ADR-0001](docs/adr/0001-shell-formatter-distribution.md)
- Fixes a bug where `format_python_string_literal` silently no-oped in real runs due to a trailing newline appended by the parser after the closing triple-quote
- Exposes `format_shell` option in the Neovim plugin (`require("snakefmt").setup({ format_shell = false })`)

Closes #170

## Test plan

- [x] Parametrised robustness suite in `tests/test_shell_formatter.py` covering all trailing-whitespace input shapes (trailing `\n`, multiple `\n`, spaces/tabs, CRLF, string prefix variants `f`, `rb`, `B`, `u`)
- [x] End-to-end behavioural tests in `tests/test_formatter.py::TestShellBlockFormatting`: default-on formats, `format_shell=False` disables, `# fmt: off` opts out, `{var}`/`{{escaped}}` placeholders survive the full pipeline
- [x] Config-path tests in `tests/test_config.py::TestShellFormattingConfig`: `format_shell = false/true` in TOML via CLI `--config`
- [x] `uv run pytest` — 288 passed, 1 xfailed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell blocks are auto-formatted with shfmt by default; toggle via CLI flag (--format-shell / --no-format-shell, -f/-F) or config.

* **Behavioral Improvements**
  * Improved heredoc handling and preservation of Snakemake placeholders and escaped braces; parse failures surface as an InvalidShell error unless formatting is disabled or scoped off.

* **Documentation**
  * README, ADRs, and plans updated with examples, CLI help, config defaults, and a new "Shell Block Formatting" section (collapsible help and examples).

* **Tests**
  * Expanded tests covering shell formatting, Python-string literal handling, heredocs, masking, and config-driven behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snakemake/snakefmt/pull/295)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->