### PR TITLE
docs: replace PyPI badges with personalized downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,8 @@ design and specifications of [Black][black].
 
 ### PyPi
 
-
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/snakefmt)
 ![PyPI - Version](https://img.shields.io/pypi/v/snakefmt)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/snakefmt)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/snakefmt?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/snakefmt)
 
 ```sh
 pip install snakefmt


### PR DESCRIPTION
Updated PyPI badges from pepy.tech

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PyPI integration badges displayed in the README's installation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->