### PR TITLE
refactor: make Formatter.align_strings a module-level function

### DIFF
--- a/snakefmt/formatter.py
+++ b/snakefmt/formatter.py
@@ -80,6 +80,34 @@ def indent_docstring(docstring: str, target_indent: int) -> str:
     return textwrap.indent(docstring, TAB * target_indent)
 
 
+def align_strings(string: str, target_indent: int) -> str:
+    """
+    Takes an ensemble of strings and indents/reindents it
+    """
+    used_indent = TAB * target_indent
+    split_string = split_code_string(string)
+    if len(split_string) == 1:
+        return textwrap.indent(split_string[0], used_indent)
+
+    # First, masks all multi-line strings
+    mask_string = "`~!@#$%^&*|?"
+    while mask_string in string:
+        mask_string += mask_string
+    mask_string = f'"""{mask_string}"""'
+    fakewrap = textwrap.indent(
+        "".join(mask_string if i % 2 else s for i, s in enumerate(split_string)),
+        used_indent,
+    )
+    split_code = fakewrap.split(mask_string)
+
+    # After indenting, we put those strings back exactly as they were
+    indented = "".join(
+        s.replace("\t", TAB) if i % 2 else split_code[i // 2]
+        for i, s in enumerate(split_string)
+    )
+    return indented
+
+
 class Formatter(Parser):
     def __init__(
         self,
@@ -136,7 +164,7 @@ class Formatter(Parser):
                     # string, so indent the whole docstring directly. See issue #303.
                     formatted = indent_docstring(formatted, self.keyword_indent)
                 else:
-                    formatted = self.align_strings(formatted, self.keyword_indent)
+                    formatted = align_strings(formatted, self.keyword_indent)
         else:
             # Invalid python syntax, eg lone 'else:' between two rules, can occur.
             # Below constructs valid code statements and formats them.
@@ -400,33 +428,6 @@ class Formatter(Parser):
             fmted = textwrap.dedent(s)
         return fmted
 
-    def align_strings(self, string: str, target_indent: int) -> str:
-        """
-        Takes an ensemble of strings and indents/reindents it
-        """
-        used_indent = TAB * target_indent
-        split_string = split_code_string(string)
-        if len(split_string) == 1:
-            return textwrap.indent(split_string[0], used_indent)
-
-        # First, masks all multi-line strings
-        mask_string = "`~!@#$%^&*|?"
-        while mask_string in string:
-            mask_string += mask_string
-        mask_string = f'"""{mask_string}"""'
-        fakewrap = textwrap.indent(
-            "".join(mask_string if i % 2 else s for i, s in enumerate(split_string)),
-            used_indent,
-        )
-        split_code = fakewrap.split(mask_string)
-
-        # After indenting, we put those strings back exactly as they were
-        indented = "".join(
-            s.replace("\t", TAB) if i % 2 else split_code[i // 2]
-            for i, s in enumerate(split_string)
-        )
-        return indented
-
     def format_param(
         self,
         parameter: Parameter,
@@ -498,7 +499,7 @@ class Formatter(Parser):
             else:
                 val = content
 
-        val = self.align_strings(val, target_indent)
+        val = align_strings(val, target_indent)
 
         result = ""
         if not inline_formatting:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -12,6 +12,7 @@ import black.parsing
 import pytest
 
 from snakefmt.exceptions import InvalidPython
+from snakefmt.formatter import align_strings
 from snakefmt.parser.grammar import SingleParam, SnakeGlobal
 from snakefmt.parser.syntax import COMMENT_SPACING
 from snakefmt.types import TAB
@@ -2292,6 +2293,24 @@ class TestDocstringHelpers:
         docstring = '"""\na\n\nb\n"""\n'
         expected = f'{TAB * 1}"""\n{TAB * 1}a\n\n{TAB * 1}b\n{TAB * 1}"""\n'
         assert indent_docstring(docstring, 1) == expected
+
+
+class TestAlignStrings:
+    """Unit tests for the align_strings helper function."""
+
+    def test_align_strings_single_line(self):
+        assert align_strings("param = 1", 1) == f"{TAB * 1}param = 1"
+        assert align_strings("param = 1", 2) == f"{TAB * 2}param = 1"
+
+    def test_align_strings_multiline_code(self):
+        code = "a = 1\nb = 2"
+        expected = f"{TAB * 1}a = 1\n{TAB * 1}b = 2"
+        assert align_strings(code, 1) == expected
+
+    def test_align_strings_preserves_triple_quoted_strings(self):
+        code = 'x = """\nline1\nline2\n"""'
+        expected = f'{TAB * 1}x = """\nline1\nline2\n"""'
+        assert align_strings(code, 1) == expected
 
 
 class TestFmtOffOn:


### PR DESCRIPTION
## Summary
- Extracted `Formatter.align_strings` to a module-level function `align_strings` in `snakefmt/formatter.py` to match consistency with other helper functions.
- Updated all call sites in `snakefmt/formatter.py` to invoke the function directly.
- Added comprehensive unit tests in `tests/test_formatter.py` to test the standalone function behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how string indentation is handled during formatting, with the logic now applied consistently across formatting paths.
* **Tests**
  * Added coverage for single-line alignment, multi-line alignment, and preserving triple-quoted strings during formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->